### PR TITLE
feat(tools): tab management — twin_tabs / twin_open / twin_close

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -39,10 +39,5 @@ module.exports = {
         '@typescript-eslint/no-var-requires': 'off',
       },
     },
-    {
-      // Service worker and other classic-script files aren't modules.
-      files: ['extension/background/**/*.js'],
-      parserOptions: { sourceType: 'script' },
-    },
   ],
 };

--- a/extension/background/service-worker.js
+++ b/extension/background/service-worker.js
@@ -1,10 +1,16 @@
 /**
- * claude-twin — service worker (MV3).
+ * claude-twin — service worker (MV3, ES module).
  *
- * Owns the offscreen document lifecycle, routes popup messages, and forwards
- * control directives to the offscreen WebSocket bridge. The actual command
- * bus / event forwarding lands with #6.
+ * - Owns the offscreen document lifecycle.
+ * - Routes popup messages.
+ * - Hosts the command dispatcher (chrome.tabs / chrome.scripting / chrome.tabGroups
+ *   are only available from extension contexts that have the right permissions —
+ *   the SW does, the offscreen does not, so dispatch lives here).
+ * - Forwards control + outbound payloads to the offscreen WS bridge.
  */
+
+import { dispatch as dispatchCommand } from '../commands/handler.js';
+import '../commands/tabs.js';
 
 const OFFSCREEN_URL = chrome.runtime.getURL('offscreen/offscreen.html');
 
@@ -77,6 +83,13 @@ chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
     handleOffscreenEvent(message.event, message.data);
     sendResponse({ ok: true });
     return;
+  }
+
+  if (message.type === 'EXECUTE_COMMAND') {
+    dispatchCommand(message.action, message.params || {})
+      .then((response) => sendResponse(response))
+      .catch((err) => sendResponse({ error: { message: err?.message || String(err) } }));
+    return true; // async sendResponse
   }
 });
 

--- a/extension/commands/handler.js
+++ b/extension/commands/handler.js
@@ -1,32 +1,27 @@
 /**
- * claude-twin — command handler.
+ * claude-twin — command dispatcher.
  *
- * Receives `command` messages forwarded from the offscreen WebSocket bridge
- * (via `chrome.runtime.sendMessage` to the service worker), dispatches them
- * to the registered action functions, and returns the result back to the
- * offscreen for the WS reply.
+ * Registry of named action handlers. Lives in the service worker so action
+ * implementations can use the full extension API surface (chrome.tabs,
+ * chrome.scripting, chrome.tabGroups, …). The offscreen document forwards
+ * inbound `command` WS messages here via `chrome.runtime.sendMessage` and
+ * wraps the response back into a `response` WS message.
  *
- * For #6 (command bus protocol) we register a single `ping` action so the
- * round-trip path is testable end-to-end. Real browser actions (search,
- * read, send, click, fill, etc.) land in #7+ as additional registrations.
+ * Built-in: `ping`. Per-platform actions (gmail/slack/etc.) register
+ * themselves from their own modules.
  */
 
 const actions = new Map();
 
 /**
  * Register an async action handler.
- * @param {string} name action name (e.g. 'ping', 'tabs', 'open')
+ * @param {string} name e.g. 'ping', 'tabs', 'open'
  * @param {(params: Record<string, unknown>) => Promise<unknown>} fn
  */
 export function registerAction(name, fn) {
   actions.set(name, fn);
 }
 
-/**
- * Look up an action by name.
- * @param {string} name
- * @returns {((params: Record<string, unknown>) => Promise<unknown>) | undefined}
- */
 export function getAction(name) {
   return actions.get(name);
 }
@@ -36,9 +31,8 @@ export function listActions() {
 }
 
 /**
- * Dispatch a command and produce the response payload (without the id —
- * the caller adds that). Returns `{ result }` on success or `{ error }`
- * on failure, matching the wire protocol.
+ * Dispatch a command and produce the response shape (without `id` —
+ * the caller adds that). `{ result }` on success, `{ error }` on failure.
  */
 export async function dispatch(action, params = {}) {
   const fn = actions.get(action);
@@ -58,7 +52,7 @@ export async function dispatch(action, params = {}) {
   }
 }
 
-// ─── Built-in actions ─────────────────────────────────────────────────────
+// ─── Built-in: ping ───────────────────────────────────────────────────────
 
 registerAction('ping', async () => ({
   pong: true,

--- a/extension/commands/tabs.js
+++ b/extension/commands/tabs.js
@@ -1,0 +1,78 @@
+/**
+ * claude-twin — tab management actions.
+ *
+ * Registers `tabs`, `open`, `close` against the SW dispatcher. New tabs
+ * default to joining the "claude-twin" tab group so background activity
+ * stays out of the user's way.
+ */
+
+import { registerAction } from './handler.js';
+
+const GROUP_TITLE = 'claude-twin';
+const GROUP_COLOR = 'purple';
+
+registerAction('tabs', async () => {
+  const tabs = await chrome.tabs.query({});
+  return {
+    tabs: tabs.map((t) => ({
+      id: t.id ?? null,
+      url: t.url ?? null,
+      title: t.title ?? null,
+      active: !!t.active,
+      windowId: t.windowId ?? null,
+      groupId: t.groupId ?? null,
+      pinned: !!t.pinned,
+    })),
+  };
+});
+
+registerAction('open', async (params) => {
+  const url = String(params.url ?? '');
+  if (!/^https?:\/\//.test(url)) {
+    throw new Error('open: url must be http(s)');
+  }
+  const active = params.active === true;
+  const group = params.group !== false; // default true
+
+  const tab = await chrome.tabs.create({ url, active });
+  if (group && tab.id !== undefined) {
+    await addToTwinGroup(tab.id).catch((err) => {
+      console.warn('[claude-twin] tabGroup add failed:', err.message);
+    });
+  }
+  return { tab_id: tab.id ?? null, url: tab.url ?? null };
+});
+
+registerAction('close', async (params) => {
+  const id = Number(params.tab_id);
+  if (!Number.isInteger(id) || id <= 0) {
+    throw new Error('close: tab_id must be a positive integer');
+  }
+  await chrome.tabs.remove(id);
+  return { closed: true, tab_id: id };
+});
+
+/**
+ * Adds a tab to the "claude-twin" tab group, creating the group if needed.
+ * The group is collapsed so it stays out of the user's way.
+ */
+async function addToTwinGroup(tabId) {
+  const tab = await chrome.tabs.get(tabId);
+  const windowId = tab.windowId;
+  if (windowId === undefined) return;
+
+  const groups = await chrome.tabGroups.query({ title: GROUP_TITLE, windowId });
+  if (groups.length > 0) {
+    const groupId = groups[0].id;
+    await chrome.tabs.group({ groupId, tabIds: [tabId] });
+    await chrome.tabGroups.update(groupId, { collapsed: true });
+    return;
+  }
+
+  const groupId = await chrome.tabs.group({ tabIds: [tabId] });
+  await chrome.tabGroups.update(groupId, {
+    title: GROUP_TITLE,
+    color: GROUP_COLOR,
+    collapsed: true,
+  });
+}

--- a/extension/offscreen/offscreen.js
+++ b/extension/offscreen/offscreen.js
@@ -14,8 +14,6 @@
  *   →  event     { type: 'event', source, eventType, data, timestamp }
  */
 
-import { dispatch as dispatchCommand } from '../commands/handler.js';
-
 const WS_URL = 'ws://127.0.0.1:9997/twin';
 const RECONNECT_BASE_MS = 1000;
 const RECONNECT_MAX_MS = 30000;
@@ -127,11 +125,20 @@ async function handleCommand(msg) {
     console.warn('[claude-twin:offscreen] malformed command (missing id/action)');
     return;
   }
-  const { result, error } = await dispatchCommand(msg.action, msg.params || {});
-  const response = { type: 'response', id: msg.id };
-  if (error) response.error = error;
-  else response.result = result;
-  send(response);
+  let response;
+  try {
+    response = await chrome.runtime.sendMessage({
+      type: 'EXECUTE_COMMAND',
+      action: msg.action,
+      params: msg.params || {},
+    });
+  } catch (err) {
+    response = { error: { message: err?.message || 'service worker unavailable' } };
+  }
+  const wire = { type: 'response', id: msg.id };
+  if (response?.error) wire.error = response.error;
+  else wire.result = response?.result ?? null;
+  send(wire);
 }
 
 function handleError() {

--- a/mcp-server/src/server.ts
+++ b/mcp-server/src/server.ts
@@ -3,6 +3,7 @@ import { WsBridge, type WsBridgeOptions } from './bridge/ws-host.js';
 import { registerPingTool } from './tools/ping.js';
 import { registerBridgeTool } from './tools/bridge.js';
 import { registerExtensionPingTool } from './tools/extension-ping.js';
+import { registerTabTools } from './tools/tabs.js';
 
 export const SERVER_NAME = 'claude-twin';
 export const SERVER_VERSION = '0.0.0';
@@ -26,6 +27,7 @@ export function createServer(opts: CreateServerOptions = {}): CreatedServer {
   registerPingTool(server);
   registerBridgeTool(server, bridge);
   registerExtensionPingTool(server, bridge);
+  registerTabTools(server, bridge);
 
   return { server, bridge };
 }

--- a/mcp-server/src/tools/_helpers.ts
+++ b/mcp-server/src/tools/_helpers.ts
@@ -1,0 +1,37 @@
+import {
+  BridgeNotConnectedError,
+  CommandFailedError,
+  CommandTimeoutError,
+} from '../bridge/ws-host.js';
+
+/**
+ * Wrap an async function that calls into `bridge.sendCommand`, mapping
+ * bridge-level errors into MCP `isError: true` results with friendly text.
+ */
+export async function runTool<R extends Record<string, unknown>>(fn: () => Promise<R>) {
+  try {
+    const payload = await fn();
+    return {
+      content: [{ type: 'text' as const, text: JSON.stringify(payload) }],
+      structuredContent: payload,
+    };
+  } catch (err) {
+    return {
+      isError: true,
+      content: [{ type: 'text' as const, text: describeBridgeError(err) }],
+    };
+  }
+}
+
+export function describeBridgeError(err: unknown): string {
+  if (err instanceof BridgeNotConnectedError) {
+    return `Extension is not connected to the bridge. Launch the claude-twin desktop app and load the extension, then retry. (${err.message})`;
+  }
+  if (err instanceof CommandTimeoutError) {
+    return `Extension did not respond within ${err.timeoutMs}ms. The browser tab may be busy or the offscreen document may have been suspended. (${err.message})`;
+  }
+  if (err instanceof CommandFailedError) {
+    return `Extension reported an error: ${err.cause.message}`;
+  }
+  return err instanceof Error ? err.message : String(err);
+}

--- a/mcp-server/src/tools/tabs.ts
+++ b/mcp-server/src/tools/tabs.ts
@@ -1,0 +1,85 @@
+import { z } from 'zod';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { WsBridge } from '../bridge/ws-host.js';
+import { runTool } from './_helpers.js';
+
+interface BrowserTab {
+  id: number | null;
+  url: string | null;
+  title: string | null;
+  active: boolean;
+  windowId: number | null;
+  groupId: number | null;
+  pinned: boolean;
+}
+
+const openSchema = {
+  url: z.string().url().describe('Absolute http(s) URL to open.'),
+  active: z.boolean().optional().describe('Focus the new tab. Defaults to false (background tab).'),
+  group: z
+    .boolean()
+    .optional()
+    .describe('Add the new tab to the "claude-twin" tab group. Defaults to true.'),
+};
+
+const closeSchema = {
+  tab_id: z
+    .number()
+    .int()
+    .positive()
+    .describe('Tab id to close (from `twin_tabs` or the `tab_id` returned by `twin_open`).'),
+};
+
+export function registerTabTools(server: McpServer, bridge: WsBridge): void {
+  server.registerTool(
+    'twin_tabs',
+    {
+      title: 'List browser tabs',
+      description:
+        "List every open tab in the user's browser. Returns id, url, title, active flag, windowId, tab-group id, and pinned flag for each tab. Use this before `twin_click` / `twin_fill` / `twin_screenshot` to pick a target.",
+      inputSchema: {},
+    },
+    async () =>
+      runTool(async () => {
+        const result = await bridge.sendCommand<{ tabs: BrowserTab[] }>('tabs', {});
+        return result;
+      }),
+  );
+
+  server.registerTool(
+    'twin_open',
+    {
+      title: 'Open a new tab',
+      description:
+        'Open a new tab in the user\'s browser. By default the tab opens in the background and joins the "claude-twin" tab group so it stays out of the user\'s active workflow. Returns the new tab id.',
+      inputSchema: openSchema,
+    },
+    async ({ url, active, group }) =>
+      runTool(async () => {
+        const params: Record<string, unknown> = { url };
+        if (active !== undefined) params.active = active;
+        if (group !== undefined) params.group = group;
+        const result = await bridge.sendCommand<{ tab_id: number | null; url: string | null }>(
+          'open',
+          params,
+        );
+        return result;
+      }),
+  );
+
+  server.registerTool(
+    'twin_close',
+    {
+      title: 'Close a tab',
+      description: 'Close the tab with the given id.',
+      inputSchema: closeSchema,
+    },
+    async ({ tab_id }) =>
+      runTool(async () => {
+        const result = await bridge.sendCommand<{ closed: true; tab_id: number }>('close', {
+          tab_id,
+        });
+        return result;
+      }),
+  );
+}


### PR DESCRIPTION
## Summary
- Three new MCP tools: `twin_tabs`, `twin_open`, `twin_close` — all wired to extension actions through the WS bridge.
- Refactor: command dispatch moves from the offscreen to the service worker (where `chrome.tabs` actually works). Offscreen now just forwards `{type:'command'}` → SW `EXECUTE_COMMAND` → wraps SW reply into WS `response`.
- New helper `tools/_helpers.ts#runTool()` standardizes the error → MCP-result mapping for every future per-tool issue.
- New tabs join a purple, collapsed \"claude-twin\" tab group by default so background work stays out of the user's way.

## Test plan
- [x] `npm run typecheck` / `lint` / `format:check` — clean
- [x] `npm run build` — green
- [ ] Manual end-to-end with the unpacked extension (deferred — tested via the round-trip harness from #6 plus per-action chrome.* mocking would land with #34)

Closes #7