### PR TITLE
feat(tools): twin_search — Google search proxy

### DIFF
--- a/extension/background/service-worker.js
+++ b/extension/background/service-worker.js
@@ -12,6 +12,7 @@
 import { dispatch as dispatchCommand } from '../commands/handler.js';
 import '../commands/tabs.js';
 import '../commands/dom.js';
+import '../commands/search.js';
 
 const OFFSCREEN_URL = chrome.runtime.getURL('offscreen/offscreen.html');
 

--- a/extension/commands/search.js
+++ b/extension/commands/search.js
@@ -1,0 +1,85 @@
+/**
+ * claude-twin — Google search proxy.
+ *
+ * Opens https://www.google.com/search?q=<query> in a background tab,
+ * scrapes the visible results (title / url / snippet), then closes the
+ * tab. Times out cleanly after 15s.
+ */
+
+import { registerAction } from './handler.js';
+
+const SEARCH_URL = 'https://www.google.com/search?q=';
+const LOAD_TIMEOUT_MS = 15_000;
+
+registerAction('search', async (params) => {
+  const query = String(params.query ?? '').trim();
+  if (!query) throw new Error('search: query is required');
+
+  const url = SEARCH_URL + encodeURIComponent(query);
+  const tab = await chrome.tabs.create({ url, active: false });
+  const tabId = tab.id;
+  if (tabId === undefined) throw new Error('search: failed to create tab');
+
+  try {
+    await waitForTabComplete(tabId, LOAD_TIMEOUT_MS);
+    const results = await chrome.scripting.executeScript({
+      target: { tabId },
+      func: scrapeResults,
+    });
+    return { query, results: results?.[0]?.result ?? [] };
+  } finally {
+    chrome.tabs.remove(tabId).catch(() => {
+      /* tab may already be gone */
+    });
+  }
+});
+
+function waitForTabComplete(tabId, timeoutMs) {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      chrome.tabs.onUpdated.removeListener(listener);
+      reject(new Error(`search: tab load timed out after ${timeoutMs}ms`));
+    }, timeoutMs);
+
+    function listener(id, info) {
+      if (id === tabId && info.status === 'complete') {
+        clearTimeout(timer);
+        chrome.tabs.onUpdated.removeListener(listener);
+        // Give Google's JS one tick to settle.
+        setTimeout(resolve, 250);
+      }
+    }
+    chrome.tabs.onUpdated.addListener(listener);
+  });
+}
+
+/**
+ * Runs in the page's main world. Returns the visible organic results from
+ * a Google SERP. Selectors are intentionally broad so they survive minor
+ * Google A/B layouts.
+ */
+function scrapeResults() {
+  const blocks = document.querySelectorAll('div.g, div[data-hveid]');
+  const results = [];
+  blocks.forEach((block) => {
+    const a = block.querySelector('a[href]:not([role="button"])');
+    if (!a) return;
+    const href = a.getAttribute('href');
+    if (!href || !href.startsWith('http')) return;
+
+    const titleEl = a.querySelector('h3') || block.querySelector('h3');
+    const title = titleEl?.textContent?.trim();
+    if (!title) return;
+
+    const snippetEl =
+      block.querySelector('[data-sncf]') ||
+      block.querySelector('div.VwiC3b') ||
+      block.querySelector('span.aCOpRe');
+    const snippet = snippetEl?.textContent?.trim() || null;
+
+    if (!results.some((r) => r.url === href)) {
+      results.push({ title, url: href, snippet });
+    }
+  });
+  return results.slice(0, 10);
+}

--- a/mcp-server/src/server.ts
+++ b/mcp-server/src/server.ts
@@ -5,6 +5,7 @@ import { registerBridgeTool } from './tools/bridge.js';
 import { registerExtensionPingTool } from './tools/extension-ping.js';
 import { registerTabTools } from './tools/tabs.js';
 import { registerDomTools } from './tools/dom.js';
+import { registerSearchTool } from './tools/search.js';
 
 export const SERVER_NAME = 'claude-twin';
 export const SERVER_VERSION = '0.0.0';
@@ -30,6 +31,7 @@ export function createServer(opts: CreateServerOptions = {}): CreatedServer {
   registerExtensionPingTool(server, bridge);
   registerTabTools(server, bridge);
   registerDomTools(server, bridge);
+  registerSearchTool(server, bridge);
 
   return { server, bridge };
 }

--- a/mcp-server/src/tools/search.ts
+++ b/mcp-server/src/tools/search.ts
@@ -1,0 +1,35 @@
+import { z } from 'zod';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { WsBridge } from '../bridge/ws-host.js';
+import { runTool } from './_helpers.js';
+
+const schema = {
+  query: z.string().min(1).max(2000).describe('Google search query.'),
+};
+
+interface SearchResult {
+  title: string;
+  url: string;
+  snippet: string | null;
+}
+
+export function registerSearchTool(server: McpServer, bridge: WsBridge): void {
+  server.registerTool(
+    'twin_search',
+    {
+      title: 'Google search',
+      description:
+        "Run a Google search and return up to 10 organic results (title / url / snippet). Opens a background tab on www.google.com, scrapes the visible SERP, and closes the tab. Times out after 15s. Useful when the user references something the agent doesn't have direct context for.",
+      inputSchema: schema,
+    },
+    async ({ query }) =>
+      runTool(async () => {
+        const result = await bridge.sendCommand<{ query: string; results: SearchResult[] }>(
+          'search',
+          { query },
+          { timeoutMs: 20_000 },
+        );
+        return result;
+      }),
+  );
+}


### PR DESCRIPTION
Stacked on #49.

## Summary
`twin_search` MCP tool routes through the extension to Google. Opens a background tab, waits for load, scrapes the organic results, returns up to 10 `{title, url, snippet}` rows, then closes the tab.

## Test plan
- [x] typecheck / lint / format:check — clean
- [ ] Manual run against a real Google SERP (deferred — A/B layout coverage tracked in follow-up)

Closes #9