### PR TITLE
feat(tools): dynamic ScriptEngine — twin_script_*

### DIFF
--- a/extension/background/service-worker.js
+++ b/extension/background/service-worker.js
@@ -13,6 +13,7 @@ import { dispatch as dispatchCommand } from '../commands/handler.js';
 import '../commands/tabs.js';
 import '../commands/dom.js';
 import '../commands/search.js';
+import '../commands/scripts.js';
 
 const OFFSCREEN_URL = chrome.runtime.getURL('offscreen/offscreen.html');
 

--- a/extension/commands/scripts.js
+++ b/extension/commands/scripts.js
@@ -1,0 +1,49 @@
+/**
+ * claude-twin — dynamic ScriptEngine actions.
+ *
+ * Wires the ScriptEngine instance into the SW dispatcher and arms
+ * `tabs.onUpdated` to auto-inject active scripts whose domain matches
+ * the loaded tab's host.
+ */
+
+import { registerAction } from './handler.js';
+import { ScriptEngine } from '../engine/script-engine.js';
+
+const engine = new ScriptEngine();
+
+chrome.tabs.onUpdated.addListener(async (tabId, info, tab) => {
+  if (info.status !== 'complete' || !tab.url) return;
+  if (tab.url.startsWith('chrome://') || tab.url.startsWith('chrome-extension://')) return;
+
+  let host;
+  try {
+    host = new URL(tab.url).hostname;
+  } catch {
+    return;
+  }
+
+  const scripts = await engine.getAll();
+  for (const s of Object.values(scripts)) {
+    if (s.active && host.endsWith(s.domain)) {
+      await engine.inject(tabId, s).catch((err) => {
+        console.warn(`[claude-twin] auto-inject ${s.id} failed:`, err.message);
+      });
+    }
+  }
+});
+
+registerAction('script_load', async ({ script }) => engine.load(script));
+
+registerAction('script_unload', async ({ id }) => engine.unload(String(id || '')));
+
+registerAction('script_toggle', async ({ id, active }) =>
+  engine.toggle(String(id || ''), !!active),
+);
+
+registerAction('script_list', async () => ({ scripts: await engine.getAll() }));
+
+registerAction('script_run', async ({ domain, code }) => {
+  if (!domain) throw new Error('script_run: domain required');
+  if (!code) throw new Error('script_run: code required');
+  return engine.runOnDomain(String(domain), String(code));
+});

--- a/extension/engine/script-engine.js
+++ b/extension/engine/script-engine.js
@@ -1,0 +1,115 @@
+/**
+ * claude-twin — dynamic script engine.
+ *
+ * Lets the MCP server push JS to the extension that auto-injects on tabs
+ * matching a domain. Scripts persist in `chrome.storage.local` so they
+ * survive SW restarts; on `tabs.onUpdated` complete, every active script
+ * whose domain matches the tab is injected.
+ */
+
+const STORAGE_KEY = 'dynamicScripts';
+
+export class ScriptEngine {
+  /** @returns {Promise<Record<string, ScriptDefinition>>} */
+  async getAll() {
+    const stored = await chrome.storage.local.get(STORAGE_KEY);
+    return stored[STORAGE_KEY] || {};
+  }
+
+  async get(id) {
+    const all = await this.getAll();
+    return all[id] || null;
+  }
+
+  /**
+   * @param {ScriptDefinition} script
+   */
+  async load(script) {
+    if (!script || typeof script !== 'object') throw new Error('script object required');
+    const id = String(script.id || '').trim();
+    const domain = String(script.domain || '').trim();
+    const code = String(script.code || '');
+    if (!id) throw new Error('script.id required');
+    if (!domain) throw new Error('script.domain required (e.g. "example.com")');
+    if (!code) throw new Error('script.code required');
+
+    const all = await this.getAll();
+    all[id] = {
+      id,
+      domain,
+      code,
+      active: script.active !== false,
+      loadedAt: Date.now(),
+      runAt: script.runAt || 'document_idle',
+    };
+    await chrome.storage.local.set({ [STORAGE_KEY]: all });
+    return all[id];
+  }
+
+  async unload(id) {
+    const all = await this.getAll();
+    if (!all[id]) return { unloaded: false, reason: 'unknown id' };
+    delete all[id];
+    await chrome.storage.local.set({ [STORAGE_KEY]: all });
+    return { unloaded: true, id };
+  }
+
+  async toggle(id, active) {
+    const all = await this.getAll();
+    if (!all[id]) throw new Error(`unknown script: ${id}`);
+    all[id].active = !!active;
+    await chrome.storage.local.set({ [STORAGE_KEY]: all });
+    return all[id];
+  }
+
+  /** Inject a script into a single tab regardless of its `active` flag. */
+  async inject(tabId, script) {
+    const code = typeof script === 'string' ? script : script?.code;
+    if (!code) throw new Error('inject: code required');
+    const results = await chrome.scripting.executeScript({
+      target: { tabId },
+      func: (body) => {
+        const fn = new Function(body);
+        return fn();
+      },
+      args: [code],
+      world: 'MAIN',
+    });
+    return results?.[0]?.result ?? null;
+  }
+
+  /** One-shot evaluation on whichever tab(s) currently match the domain. */
+  async runOnDomain(domain, code) {
+    const tabs = await chrome.tabs.query({});
+    const matches = tabs.filter((t) => {
+      try {
+        return new URL(t.url || '').hostname.endsWith(domain);
+      } catch {
+        return false;
+      }
+    });
+    if (matches.length === 0) {
+      return { ran: false, reason: `no open tab matching ${domain}` };
+    }
+    const results = [];
+    for (const t of matches) {
+      if (t.id === undefined) continue;
+      try {
+        results.push({ tabId: t.id, result: await this.inject(t.id, code) });
+      } catch (err) {
+        results.push({ tabId: t.id, error: err.message });
+      }
+    }
+    return { ran: true, results };
+  }
+}
+
+/**
+ * @typedef {Object} ScriptDefinition
+ * @property {string} id
+ * @property {string} domain  e.g. "github.com"
+ * @property {string} code
+ * @property {boolean} [active]
+ * @property {number} [loadedAt]
+ * @property {string} [runAt]
+ */

--- a/mcp-server/src/server.ts
+++ b/mcp-server/src/server.ts
@@ -6,6 +6,7 @@ import { registerExtensionPingTool } from './tools/extension-ping.js';
 import { registerTabTools } from './tools/tabs.js';
 import { registerDomTools } from './tools/dom.js';
 import { registerSearchTool } from './tools/search.js';
+import { registerScriptTools } from './tools/scripts.js';
 
 export const SERVER_NAME = 'claude-twin';
 export const SERVER_VERSION = '0.0.0';
@@ -32,6 +33,7 @@ export function createServer(opts: CreateServerOptions = {}): CreatedServer {
   registerTabTools(server, bridge);
   registerDomTools(server, bridge);
   registerSearchTool(server, bridge);
+  registerScriptTools(server, bridge);
 
   return { server, bridge };
 }

--- a/mcp-server/src/tools/scripts.ts
+++ b/mcp-server/src/tools/scripts.ts
@@ -1,0 +1,91 @@
+import { z } from 'zod';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { WsBridge } from '../bridge/ws-host.js';
+import { runTool } from './_helpers.js';
+
+const scriptDefinition = z
+  .object({
+    id: z.string().min(1).describe('Stable identifier — used by unload / toggle / list.'),
+    domain: z
+      .string()
+      .min(1)
+      .describe('Hostname suffix to match (e.g. "github.com" matches "www.github.com").'),
+    code: z.string().min(1).describe('JavaScript body to evaluate via `new Function(code)()`.'),
+    active: z
+      .boolean()
+      .optional()
+      .describe('If true (default), the script auto-injects on matching tabs as they load.'),
+    runAt: z
+      .enum(['document_start', 'document_end', 'document_idle'])
+      .optional()
+      .describe('Reserved — currently always document_idle (after `tabs.onUpdated` complete).'),
+  })
+  .describe('Dynamic script definition.');
+
+const loadSchema = { script: scriptDefinition };
+const idSchema = { id: z.string().min(1) };
+const toggleSchema = { id: z.string().min(1), active: z.boolean() };
+const runSchema = {
+  domain: z
+    .string()
+    .min(1)
+    .describe('Hostname suffix; matches every open tab whose host ends with this.'),
+  code: z.string().min(1).describe('JavaScript body to evaluate in MAIN world.'),
+};
+
+export function registerScriptTools(server: McpServer, bridge: WsBridge): void {
+  server.registerTool(
+    'twin_script_load',
+    {
+      title: 'Load a dynamic script',
+      description:
+        'Register a JavaScript snippet that the extension will inject into every tab whose host ends with `domain`. Scripts persist in `chrome.storage.local` so they survive SW restarts. Use `active: false` to register without auto-injecting.',
+      inputSchema: loadSchema,
+    },
+    async ({ script }) => runTool(async () => bridge.sendCommand('script_load', { script })),
+  );
+
+  server.registerTool(
+    'twin_script_unload',
+    {
+      title: 'Unload a dynamic script',
+      description: 'Remove a previously loaded dynamic script by id.',
+      inputSchema: idSchema,
+    },
+    async ({ id }) => runTool(async () => bridge.sendCommand('script_unload', { id })),
+  );
+
+  server.registerTool(
+    'twin_script_toggle',
+    {
+      title: 'Toggle a dynamic script active flag',
+      description:
+        'Flip the `active` flag on a registered script. Inactive scripts stay registered but do not auto-inject.',
+      inputSchema: toggleSchema,
+    },
+    async ({ id, active }) =>
+      runTool(async () => bridge.sendCommand('script_toggle', { id, active })),
+  );
+
+  server.registerTool(
+    'twin_script_list',
+    {
+      title: 'List dynamic scripts',
+      description: 'Return the dynamic-script registry as `{ scripts: { id: definition } }`.',
+      inputSchema: {},
+    },
+    async () => runTool(async () => bridge.sendCommand('script_list', {})),
+  );
+
+  server.registerTool(
+    'twin_script_run',
+    {
+      title: 'Run a one-shot script on matching tabs',
+      description:
+        'Evaluate JavaScript on every currently open tab whose host ends with `domain`. Does not register the script in the persistent registry. Use `twin_script_load` if you want auto-injection on future tab loads.',
+      inputSchema: runSchema,
+    },
+    async ({ domain, code }) =>
+      runTool(async () => bridge.sendCommand('script_run', { domain, code })),
+  );
+}


### PR DESCRIPTION
Stacked on #50.

Five MCP tools backed by a ported `ScriptEngine` and an auto-injection `tabs.onUpdated` listener.

Closes #10