### PR TITLE
feat(tools): DOM interaction — twin_click / twin_fill / twin_screenshot

### DIFF
--- a/extension/background/service-worker.js
+++ b/extension/background/service-worker.js
@@ -11,6 +11,7 @@
 
 import { dispatch as dispatchCommand } from '../commands/handler.js';
 import '../commands/tabs.js';
+import '../commands/dom.js';
 
 const OFFSCREEN_URL = chrome.runtime.getURL('offscreen/offscreen.html');
 

--- a/extension/commands/dom.js
+++ b/extension/commands/dom.js
@@ -1,0 +1,114 @@
+/**
+ * claude-twin — DOM interaction actions.
+ *
+ * Registers `click`, `fill`, `screenshot`. Honours a small selector
+ * blocklist so the bridge never auto-fills credential fields without an
+ * explicit user-side override.
+ */
+
+import { registerAction } from './handler.js';
+
+const BLOCKED_SELECTOR_PATTERNS = [
+  /\[type=["']?password["']?\]/i,
+  /input\[type=["']?password["']?\]/i,
+  /\[autocomplete=["']?(current|new)-password["']?\]/i,
+  /#password\b/,
+  /\[name=["']?password["']?\]/i,
+];
+
+function isBlockedSelector(selector) {
+  if (typeof selector !== 'string' || selector.trim() === '') return true;
+  return BLOCKED_SELECTOR_PATTERNS.some((re) => re.test(selector));
+}
+
+async function execInTab(tabId, func, args) {
+  const results = await chrome.scripting.executeScript({
+    target: { tabId },
+    func,
+    args,
+    world: 'MAIN',
+  });
+  return results?.[0]?.result;
+}
+
+registerAction('click', async (params) => {
+  const tabId = Number(params.tab_id);
+  const selector = String(params.selector ?? '');
+  if (!Number.isInteger(tabId) || tabId <= 0) {
+    throw new Error('click: tab_id must be a positive integer');
+  }
+  if (isBlockedSelector(selector)) {
+    throw new Error(`click: selector blocked by safety policy (${selector})`);
+  }
+
+  const ok = await execInTab(
+    tabId,
+    (sel) => {
+      const el = document.querySelector(sel);
+      if (!el) return { clicked: false, reason: 'selector did not match' };
+      el.click?.();
+      return { clicked: true };
+    },
+    [selector],
+  );
+  if (!ok?.clicked) {
+    throw new Error(ok?.reason ?? 'click failed');
+  }
+  return { clicked: true, selector, tab_id: tabId };
+});
+
+registerAction('fill', async (params) => {
+  const tabId = Number(params.tab_id);
+  const selector = String(params.selector ?? '');
+  const value = String(params.value ?? '');
+  if (!Number.isInteger(tabId) || tabId <= 0) {
+    throw new Error('fill: tab_id must be a positive integer');
+  }
+  if (isBlockedSelector(selector)) {
+    throw new Error(`fill: selector blocked by safety policy (${selector})`);
+  }
+
+  const ok = await execInTab(
+    tabId,
+    (sel, val) => {
+      const el = document.querySelector(sel);
+      if (!el) return { filled: false, reason: 'selector did not match' };
+      const tag = el.tagName?.toLowerCase();
+      if (tag === 'input' || tag === 'textarea') {
+        const proto = tag === 'input' ? HTMLInputElement.prototype : HTMLTextAreaElement.prototype;
+        const setter = Object.getOwnPropertyDescriptor(proto, 'value')?.set;
+        setter?.call(el, val);
+        el.dispatchEvent(new Event('input', { bubbles: true }));
+        el.dispatchEvent(new Event('change', { bubbles: true }));
+        return { filled: true };
+      }
+      if (el.isContentEditable) {
+        el.textContent = val;
+        el.dispatchEvent(new InputEvent('input', { bubbles: true }));
+        return { filled: true };
+      }
+      return { filled: false, reason: `unsupported element type: ${tag}` };
+    },
+    [selector, value],
+  );
+  if (!ok?.filled) {
+    throw new Error(ok?.reason ?? 'fill failed');
+  }
+  return { filled: true, selector, tab_id: tabId };
+});
+
+registerAction('screenshot', async (params) => {
+  const tabId = Number(params.tab_id);
+  if (!Number.isInteger(tabId) || tabId <= 0) {
+    throw new Error('screenshot: tab_id must be a positive integer');
+  }
+
+  const tab = await chrome.tabs.get(tabId);
+  const windowId = tab.windowId;
+  if (windowId === undefined) {
+    throw new Error('screenshot: tab has no associated window');
+  }
+
+  const dataUrl = await chrome.tabs.captureVisibleTab(windowId, { format: 'png' });
+  return { data_url: dataUrl, tab_id: tabId };
+});

--- a/mcp-server/src/server.ts
+++ b/mcp-server/src/server.ts
@@ -4,6 +4,7 @@ import { registerPingTool } from './tools/ping.js';
 import { registerBridgeTool } from './tools/bridge.js';
 import { registerExtensionPingTool } from './tools/extension-ping.js';
 import { registerTabTools } from './tools/tabs.js';
+import { registerDomTools } from './tools/dom.js';
 
 export const SERVER_NAME = 'claude-twin';
 export const SERVER_VERSION = '0.0.0';
@@ -28,6 +29,7 @@ export function createServer(opts: CreateServerOptions = {}): CreatedServer {
   registerBridgeTool(server, bridge);
   registerExtensionPingTool(server, bridge);
   registerTabTools(server, bridge);
+  registerDomTools(server, bridge);
 
   return { server, bridge };
 }

--- a/mcp-server/src/tools/dom.ts
+++ b/mcp-server/src/tools/dom.ts
@@ -1,0 +1,81 @@
+import { z } from 'zod';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { WsBridge } from '../bridge/ws-host.js';
+import { runTool } from './_helpers.js';
+
+const tabIdSchema = z.number().int().positive().describe('Tab id from `twin_tabs` or `twin_open`.');
+
+const clickSchema = {
+  tab_id: tabIdSchema,
+  selector: z.string().min(1).describe('CSS selector of the element to click.'),
+};
+
+const fillSchema = {
+  tab_id: tabIdSchema,
+  selector: z
+    .string()
+    .min(1)
+    .describe('CSS selector of an input / textarea / contenteditable element.'),
+  value: z.string().describe('Value to set on the element.'),
+};
+
+const screenshotSchema = {
+  tab_id: tabIdSchema,
+};
+
+export function registerDomTools(server: McpServer, bridge: WsBridge): void {
+  server.registerTool(
+    'twin_click',
+    {
+      title: 'Click an element',
+      description:
+        'Click the element matching the given CSS selector in a target tab. Selectors that look like password fields (`input[type=password]`, `[autocomplete=current-password]`, etc.) are blocked by safety policy.',
+      inputSchema: clickSchema,
+    },
+    async ({ tab_id, selector }) =>
+      runTool(async () => {
+        const result = await bridge.sendCommand<{
+          clicked: true;
+          selector: string;
+          tab_id: number;
+        }>('click', { tab_id, selector });
+        return result;
+      }),
+  );
+
+  server.registerTool(
+    'twin_fill',
+    {
+      title: 'Fill a form field',
+      description:
+        'Set the value of an input / textarea / contenteditable element. Dispatches `input` and `change` events so frameworks (React / Vue / Angular) pick the change up. Password-shaped selectors are blocked by safety policy.',
+      inputSchema: fillSchema,
+    },
+    async ({ tab_id, selector, value }) =>
+      runTool(async () => {
+        const result = await bridge.sendCommand<{ filled: true; selector: string; tab_id: number }>(
+          'fill',
+          { tab_id, selector, value },
+        );
+        return result;
+      }),
+  );
+
+  server.registerTool(
+    'twin_screenshot',
+    {
+      title: 'Screenshot the visible part of a tab',
+      description:
+        "Capture a PNG screenshot of the visible viewport of the target tab (Chrome `tabs.captureVisibleTab`). Returns a `data:image/png;base64,...` URL. Cannot capture content blocked by `<iframe>` cross-origin policies; that's a Chrome limitation.",
+      inputSchema: screenshotSchema,
+    },
+    async ({ tab_id }) =>
+      runTool(async () => {
+        const result = await bridge.sendCommand<{ data_url: string; tab_id: number }>(
+          'screenshot',
+          { tab_id },
+        );
+        return result;
+      }),
+  );
+}


### PR DESCRIPTION
Replaces #49 (auto-closed when stacked PR #48 was squashed).

Closes #8