### PR TITLE
feat(platforms): port all 17 content scripts + 3 shared modules

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -39,5 +39,23 @@ module.exports = {
         '@typescript-eslint/no-var-requires': 'off',
       },
     },
+    {
+      // Content scripts run as classic scripts (manifest v3 isolated world,
+      // not modules) and lean on globals attached by content/shared/*.js
+      // (TwinMonitor, TwinMessenger, TwinLanguage).
+      files: ['extension/content/**/*.js'],
+      parserOptions: { sourceType: 'script' },
+      globals: {
+        TwinMonitor: 'readonly',
+        TwinMessenger: 'readonly',
+        TwinLanguage: 'readonly',
+      },
+      rules: {
+        '@typescript-eslint/no-unused-vars': 'off',
+        'no-empty': 'off',
+        'no-prototype-builtins': 'off',
+        'no-inner-declarations': 'off',
+      },
+    },
   ],
 };

--- a/extension/background/service-worker.js
+++ b/extension/background/service-worker.js
@@ -94,6 +94,26 @@ chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
       .catch((err) => sendResponse({ error: { message: err?.message || String(err) } }));
     return true; // async sendResponse
   }
+
+  // Anything else with a string `type` from a content script is a platform
+  // event. Wrap it as `{type:'event', ...}` and forward over WS.
+  if (typeof message.type === 'string' && _sender?.tab) {
+    let source = 'unknown';
+    try {
+      source = new URL(_sender.tab.url || '').hostname.replace(/^www\./, '');
+    } catch {
+      /* ignore */
+    }
+    void forwardToOffscreen({
+      type: 'event',
+      source,
+      eventType: message.type,
+      data: message.data ?? message,
+      timestamp: Date.now(),
+    });
+    sendResponse({ ok: true });
+    return;
+  }
 });
 
 async function handleOffscreenEvent(event, data) {

--- a/extension/content/calcom.js
+++ b/extension/content/calcom.js
@@ -1,0 +1,33 @@
+/**
+ * Orchestra Twin Bridge — Cal.com Content Script
+ */
+
+(() => {
+  if (window.__TwinCalComLoaded) return;
+  window.__TwinCalComLoaded = true;
+
+  const monitor = new TwinMonitor('calcom');
+
+  const sendBookingSummary = monitor.debounce(() => {
+    const bookings = document.querySelectorAll("[data-testid='booking-item']");
+    const upcoming = document.querySelectorAll(
+      "[data-testid='upcoming'] [data-testid='booking-item']",
+    );
+
+    if (monitor.hasChanged('calcom_bookings', bookings.length)) {
+      monitor.send('CALCOM_BOOKINGS_LOADED', {
+        totalBookings: bookings.length,
+        upcomingCount: upcoming.length,
+        url: location.href,
+      });
+    }
+  }, 2000);
+
+  monitor.watch('main', sendBookingSummary, {
+    observeId: 'main',
+    childList: true,
+    subtree: false,
+  });
+
+  sendBookingSummary();
+})();

--- a/extension/content/claude-usage.js
+++ b/extension/content/claude-usage.js
@@ -1,0 +1,64 @@
+/**
+ * Orchestra Twin Bridge — Claude.ai Usage Content Script
+ */
+
+(() => {
+  if (window.__TwinClaudeUsageLoaded) return;
+  window.__TwinClaudeUsageLoaded = true;
+
+  // Only run on settings/usage pages
+  if (!location.pathname.startsWith('/settings') && !location.pathname.startsWith('/usage')) return;
+
+  const monitor = new TwinMonitor('claude');
+
+  const SEL = {
+    usageContainer: '[data-testid="usage-section"], .usage-section, main [class*="usage"]',
+    planBadge: '[data-testid="plan-badge"], [class*="plan-badge"], [class*="subscription-tier"]',
+    tokensUsed: '[data-testid="tokens-used"], [class*="tokens-used"], [class*="usage-amount"]',
+    creditsLeft: '[data-testid="credits-remaining"], [class*="credits-remaining"]',
+    periodLabel: '[data-testid="billing-period"], [class*="billing-period"], [class*="reset-date"]',
+    totalCost: '[data-testid="total-cost"], [class*="total-cost"], [class*="amount-due"]',
+  };
+
+  const parseNumber = (text) => {
+    if (!text) return null;
+    const match = text.replace(/,/g, '').match(/[\d.]+/);
+    return match ? parseFloat(match[0]) : null;
+  };
+
+  const sendUsageUpdate = monitor.debounce(() => {
+    const planEl = document.querySelector(SEL.planBadge);
+    const tokensEl = document.querySelector(SEL.tokensUsed);
+    const creditsEl = document.querySelector(SEL.creditsLeft);
+    const periodEl = document.querySelector(SEL.periodLabel);
+    const totalEl = document.querySelector(SEL.totalCost);
+
+    const payload = {
+      plan: planEl?.textContent?.trim() || null,
+      tokens_used: parseNumber(tokensEl?.textContent),
+      credits_remaining: parseNumber(creditsEl?.textContent),
+      period: periodEl?.textContent?.trim() || null,
+      total: parseNumber(totalEl?.textContent),
+      url: location.href,
+    };
+
+    if (monitor.hasChanged('claude_usage', payload)) {
+      monitor.send('cost_update', { source: 'claude', type: 'cost_update', data: payload });
+    }
+  }, 2000);
+
+  monitor.watch(SEL.usageContainer, sendUsageUpdate, {
+    observeId: 'usage-main',
+    childList: true,
+    subtree: true,
+  });
+
+  // SPA navigation (claude.ai is React-based)
+  const origPushState = history.pushState.bind(history);
+  history.pushState = function (...args) {
+    origPushState(...args);
+    setTimeout(sendUsageUpdate, 600);
+  };
+
+  sendUsageUpdate();
+})();

--- a/extension/content/discord.js
+++ b/extension/content/discord.js
@@ -1,0 +1,39 @@
+/**
+ * Orchestra Twin Bridge — Discord Content Script
+ */
+
+(() => {
+  if (window.__TwinDiscordLoaded) return;
+  window.__TwinDiscordLoaded = true;
+
+  const monitor = new TwinMonitor('discord');
+
+  const sendUnreadSummary = monitor.debounce(() => {
+    const unread = document.querySelectorAll('[class*="unread"]');
+    const mentions = document.querySelectorAll('[class*="badge"]');
+
+    let mentionCount = 0;
+    mentions.forEach((el) => {
+      const n = parseInt(el.textContent, 10);
+      if (!isNaN(n)) mentionCount += n;
+    });
+
+    if (monitor.hasChanged('discord_unread', { unread: unread.length, mentionCount })) {
+      monitor.send('DISCORD_UNREAD_SUMMARY', {
+        unreadChannels: unread.length,
+        mentionCount,
+        url: location.href,
+      });
+    }
+  }, 2000);
+
+  monitor.watch('[class*="sidebar"]', sendUnreadSummary, {
+    observeId: 'sidebar',
+    childList: true,
+    subtree: true,
+    attributes: true,
+    attributeFilter: ['class'],
+  });
+
+  sendUnreadSummary();
+})();

--- a/extension/content/gcal.js
+++ b/extension/content/gcal.js
@@ -1,0 +1,33 @@
+/**
+ * Orchestra Twin Bridge — Google Calendar Content Script
+ */
+
+(() => {
+  if (window.__TwinGCalLoaded) return;
+  window.__TwinGCalLoaded = true;
+
+  const monitor = new TwinMonitor('gcal');
+
+  const sendCalendarContext = monitor.debounce(() => {
+    const events = document.querySelectorAll('[data-eventid]');
+    const todayEvents = Array.from(events)
+      .slice(0, 10)
+      .map((el) => ({
+        title: el.getAttribute('data-eventid') || el.textContent?.trim()?.slice(0, 50),
+      }));
+
+    if (monitor.hasChanged('gcal_eventCount', events.length)) {
+      monitor.send('GCAL_EVENTS_LOADED', {
+        eventCount: events.length,
+        todayEventCount: todayEvents.length,
+        url: location.href,
+      });
+    }
+  }, 2000);
+
+  // Calendar re-renders on navigation
+  const observer = new MutationObserver(() => sendCalendarContext());
+  observer.observe(document.body, { childList: true, subtree: false });
+
+  sendCalendarContext();
+})();

--- a/extension/content/gcp-billing.js
+++ b/extension/content/gcp-billing.js
@@ -1,0 +1,79 @@
+/**
+ * Orchestra Twin Bridge — GCP Billing Content Script
+ */
+
+(() => {
+  if (window.__TwinGcpBillingLoaded) return;
+  window.__TwinGcpBillingLoaded = true;
+
+  // Only run on billing-related pages
+  if (!location.pathname.includes('/billing')) return;
+
+  const monitor = new TwinMonitor('gcp');
+
+  const SEL = {
+    totalCost:
+      '[data-test-id="cost-summary-total"], .cfc-billing-account-overview-cost-amount, [jsname="cost-amount"]',
+    costCards: '[data-test-id="cost-card"], .cfc-billing-service-cost-card, .billing-summary-card',
+    serviceRows: 'table tr[data-test-id], .cfc-billing-account-cost-table tbody tr',
+    projectName:
+      '[data-test-id="project-name"], .cfc-billing-account-name, .billing-account-display-name',
+    currency: '[data-test-id="currency-code"], .currency-code',
+  };
+
+  const parseCost = (text) => {
+    if (!text) return null;
+    const match = text.replace(/,/g, '').match(/[\d.]+/);
+    return match ? parseFloat(match[0]) : null;
+  };
+
+  const sendCostUpdate = monitor.debounce(() => {
+    const totalEl = document.querySelector(SEL.totalCost);
+    const projectEl = document.querySelector(SEL.projectName);
+    const currencyEl = document.querySelector(SEL.currency);
+
+    const total = parseCost(totalEl?.textContent);
+    const project = projectEl?.textContent?.trim() || null;
+    const currency = currencyEl?.textContent?.trim() || 'USD';
+
+    // Build breakdown from service rows
+    const rows = document.querySelectorAll(SEL.serviceRows);
+    const breakdown = Array.from(rows)
+      .slice(0, 10)
+      .reduce((acc, row) => {
+        const cells = row.querySelectorAll('td');
+        if (cells.length >= 2) {
+          const service = cells[0]?.textContent?.trim();
+          const cost = parseCost(cells[cells.length - 1]?.textContent);
+          if (service && cost !== null) acc.push({ service, cost });
+        }
+        return acc;
+      }, []);
+
+    const payload = { total, currency, breakdown, project, url: location.href };
+
+    if (monitor.hasChanged('gcp_cost', payload)) {
+      monitor.send('cost_update', { source: 'gcp', type: 'cost_update', data: payload });
+    }
+  }, 2000);
+
+  // Watch the main billing summary container
+  monitor.watch(
+    '[data-test-id="billing-overview"], .cfc-billing-account-overview, main',
+    sendCostUpdate,
+    {
+      observeId: 'billing-main',
+      childList: true,
+      subtree: true,
+    },
+  );
+
+  // SPA navigation (GCP is a single-page app)
+  const origPushState = history.pushState.bind(history);
+  history.pushState = function (...args) {
+    origPushState(...args);
+    setTimeout(sendCostUpdate, 800);
+  };
+
+  sendCostUpdate();
+})();

--- a/extension/content/github.js
+++ b/extension/content/github.js
@@ -1,0 +1,86 @@
+/**
+ * Orchestra Twin Bridge — GitHub Content Script
+ */
+
+(() => {
+  if (window.__TwinGitHubLoaded) return;
+  window.__TwinGitHubLoaded = true;
+
+  const monitor = new TwinMonitor('github');
+
+  // ─── Notification Count ────────────────────────────────────────────────────
+
+  const sendNotificationCount = monitor.debounce(() => {
+    const badge = document.querySelector('.mail-status');
+    const hasUnread = !!document.querySelector('[aria-label="You have unread notifications"]');
+    const count = badge ? parseInt(badge.textContent.trim(), 10) || 0 : 0;
+
+    if (monitor.hasChanged('notifCount', count)) {
+      monitor.send('GITHUB_NOTIFICATIONS', { count, hasUnread, url: location.href });
+    }
+  }, 2000);
+
+  // ─── PR / Issue Context ────────────────────────────────────────────────────
+
+  const sendPageContext = monitor.debounce(() => {
+    const path = location.pathname;
+
+    // Notification list page
+    if (path === '/notifications') {
+      const items = document.querySelectorAll('.notifications-list-item');
+      const unread = Array.from(items).filter((el) => el.classList.contains('unread'));
+      monitor.send('GITHUB_NOTIFICATION_LIST', {
+        total: items.length,
+        unread: unread.length,
+      });
+      return;
+    }
+
+    // PR or issue page
+    const prMatch = path.match(/\/([^/]+)\/([^/]+)\/(pull|issues)\/(\d+)/);
+    if (prMatch) {
+      const [, owner, repo, type, number] = prMatch;
+      const title = document.querySelector('.js-issue-title')?.textContent?.trim();
+      const state = document.querySelector('.State')?.textContent?.trim();
+      const reviews = document.querySelectorAll('.review-summary-container').length;
+
+      monitor.send('GITHUB_PR_CONTEXT', {
+        owner,
+        repo,
+        type,
+        number: parseInt(number, 10),
+        title,
+        state,
+        reviews,
+        url: location.href,
+      });
+    }
+  }, 1500);
+
+  // ─── Watchers ──────────────────────────────────────────────────────────────
+
+  monitor.watch(
+    'head title',
+    () => {
+      sendNotificationCount();
+      sendPageContext();
+    },
+    {
+      observeId: 'title',
+      childList: true,
+      subtree: true,
+      characterData: true,
+    },
+  );
+
+  // Navigation events (GitHub is a SPA)
+  const origPushState = history.pushState.bind(history);
+  history.pushState = function (...args) {
+    origPushState(...args);
+    setTimeout(sendPageContext, 800);
+  };
+  window.addEventListener('popstate', () => setTimeout(sendPageContext, 800));
+
+  sendNotificationCount();
+  sendPageContext();
+})();

--- a/extension/content/gmail.js
+++ b/extension/content/gmail.js
@@ -1,0 +1,80 @@
+/**
+ * Orchestra Twin Bridge — Gmail Content Script
+ */
+
+(() => {
+  if (window.__TwinGmailLoaded) return;
+  window.__TwinGmailLoaded = true;
+
+  const monitor = new TwinMonitor('gmail');
+
+  // Load selectors from config (embedded for performance)
+  const SEL = {
+    unreadBadge: '.bsU',
+    conversationList: '.zA',
+    openConversation: '.h7',
+    sender: '.yW span[email]',
+    subject: '.hP',
+    preview: '.y2',
+  };
+
+  // ─── Unread Count ──────────────────────────────────────────────────────────
+
+  const sendUnreadCount = monitor.debounce(() => {
+    const badge = document.querySelector(SEL.unreadBadge);
+    const count = badge ? parseInt(badge.textContent.trim(), 10) || 0 : 0;
+
+    if (monitor.hasChanged('unreadCount', count)) {
+      monitor.send('GMAIL_UNREAD_COUNT', { count, url: location.href });
+    }
+  }, 1500);
+
+  // ─── New Email Detection ───────────────────────────────────────────────────
+
+  const sendNewEmails = monitor.debounce(() => {
+    const rows = document.querySelectorAll(`${SEL.conversationList}.zE`); // .zE = unread
+    const emails = Array.from(rows)
+      .slice(0, 5)
+      .map((row) => {
+        const senderEl = row.querySelector(SEL.sender);
+        const subjectEl = row.querySelector(SEL.subject);
+        const previewEl = row.querySelector(SEL.preview);
+        const lang = TwinLanguage.detectLanguage(subjectEl?.textContent || '');
+        return {
+          sender: senderEl?.getAttribute('email') || senderEl?.textContent?.trim(),
+          subject: subjectEl?.textContent?.trim(),
+          preview: previewEl?.textContent?.trim()?.slice(0, 100),
+          lang,
+        };
+      });
+
+    if (emails.length > 0 && monitor.hasChanged('unreadEmails', emails)) {
+      monitor.send('GMAIL_NEW_EMAILS', { emails, count: rows.length });
+    }
+  }, 2000);
+
+  // ─── Watchers ──────────────────────────────────────────────────────────────
+
+  monitor.watch(
+    SEL.conversationList,
+    () => {
+      sendUnreadCount();
+      sendNewEmails();
+    },
+    { observeId: 'inbox', childList: true, subtree: false },
+  );
+
+  // Also watch badge directly
+  monitor.watch(
+    SEL.unreadBadge,
+    () => {
+      sendUnreadCount();
+    },
+    { observeId: 'badge', childList: true, characterData: true, subtree: true },
+  );
+
+  // ─── Initial Scan ──────────────────────────────────────────────────────────
+
+  sendUnreadCount();
+  sendNewEmails();
+})();

--- a/extension/content/gmeet.js
+++ b/extension/content/gmeet.js
@@ -1,0 +1,277 @@
+/**
+ * Orchestra Twin Bridge — Google Meet Content Script
+ *
+ * Monitors:
+ * - Meeting start/end detection
+ * - Live caption extraction via MutationObserver
+ * - Participant list collection
+ *
+ * Privacy: all caption data stays local. Caption monitoring is OPT-IN.
+ * A meeting_detected event is sent first; the service worker handles the
+ * opt-in prompt before captions are forwarded.
+ */
+
+(() => {
+  if (window.__TwinGMeetLoaded) return;
+  window.__TwinGMeetLoaded = true;
+
+  const monitor = new TwinMonitor('gmeet');
+  const detectLanguage = (text) => window.TwinLanguage?.detectLanguage(text) ?? 'unknown';
+
+  // ─── State ─────────────────────────────────────────────────────────────────
+
+  let meetingActive = false;
+  let captionsEnabled = false; // Only true after user opts in
+  let captionObserver = null;
+  let meetingId = null; // Ephemeral local ID for grouping captions
+
+  // ─── Helpers ───────────────────────────────────────────────────────────────
+
+  function getMeetingTitle() {
+    // Google Meet places the meeting code/title in several possible locations
+    return (
+      document.querySelector('[data-meeting-title]')?.getAttribute('data-meeting-title') ||
+      document.querySelector('.u6vdEc')?.textContent?.trim() ||
+      document.querySelector('[data-meeting-code]')?.getAttribute('data-meeting-code') ||
+      document.title?.replace(' - Google Meet', '').trim() ||
+      null
+    );
+  }
+
+  function getParticipants() {
+    // Collect participant names from the grid/list view
+    const names = new Set();
+
+    // Tile view: each participant tile has a label
+    document.querySelectorAll('[data-participant-id]').forEach((el) => {
+      const name = el.querySelector('[data-self-name], .zWGUib, .NsV7d')?.textContent?.trim();
+      if (name) names.add(name);
+    });
+
+    // People panel (opened sidebar)
+    document.querySelectorAll('[data-requested-participant-id], .rua5Nb .cS7sFc').forEach((el) => {
+      const name = el.querySelector('.zWGUib, .NsV7d, [data-name]')?.textContent?.trim();
+      if (name) names.add(name);
+    });
+
+    return [...names];
+  }
+
+  function isInMeeting() {
+    // Reliable meeting indicators: participant tiles visible OR toolbar visible
+    const hasTiles = document.querySelectorAll('[data-participant-id]').length > 0;
+    const hasToolbar = !!document.querySelector(
+      '[data-call-ended="false"], [jscontroller="kAPMuc"]',
+    );
+    return hasTiles || hasToolbar;
+  }
+
+  // ─── Caption Monitoring ────────────────────────────────────────────────────
+
+  /**
+   * Caption containers in Google Meet:
+   * - The main caption area is typically a div with role="region" or a
+   *   specific aria-label containing "Captions".
+   * - Each caption line contains a speaker name and the caption text.
+   *
+   * Known selectors (subject to Google Meet updates):
+   *   .a4cQT          — caption container
+   *   .TBMuR          — individual caption item
+   *   .zs7s8d.jxFHg   — speaker name within caption
+   *   .Mz6pEf         — caption text span
+   *
+   * We use multiple selectors with fallbacks for resilience.
+   */
+  const CAPTION_CONTAINER_SELECTORS = [
+    '.a4cQT',
+    '[jsname="tgaKEf"]',
+    '[aria-label*="aption"]',
+    '[class*="caption-container"]',
+  ];
+
+  const CAPTION_ITEM_SELECTORS = ['.TBMuR', '[jsname="YSg4Rb"]', '[class*="caption-item"]'];
+  const SPEAKER_SELECTORS = ['.zs7s8d', '[jsname="r4nke"]', '[class*="speaker"]'];
+  const TEXT_SELECTORS = ['.Mz6pEf', '[jsname="tC8NTb"]', '[class*="caption-text"]'];
+
+  function findCaptionContainer() {
+    for (const sel of CAPTION_CONTAINER_SELECTORS) {
+      const el = document.querySelector(sel);
+      if (el) return el;
+    }
+    return null;
+  }
+
+  function extractCaptionItems(container) {
+    for (const sel of CAPTION_ITEM_SELECTORS) {
+      const items = container.querySelectorAll(sel);
+      if (items.length > 0) return items;
+    }
+    // Fallback: direct children that look like caption lines
+    return container.querySelectorAll(':scope > div');
+  }
+
+  function extractSpeakerText(item) {
+    let speaker = '';
+    let text = '';
+
+    for (const sel of SPEAKER_SELECTORS) {
+      const el = item.querySelector(sel);
+      if (el) {
+        speaker = el.textContent?.trim() ?? '';
+        break;
+      }
+    }
+
+    for (const sel of TEXT_SELECTORS) {
+      const el = item.querySelector(sel);
+      if (el) {
+        text = el.textContent?.trim() ?? '';
+        break;
+      }
+    }
+
+    // Fallback: if no specific elements found, try to split container text
+    if (!text && !speaker) {
+      const full = item.textContent?.trim() ?? '';
+      const colonIdx = full.indexOf(':');
+      if (colonIdx > 0 && colonIdx < 40) {
+        speaker = full.slice(0, colonIdx).trim();
+        text = full.slice(colonIdx + 1).trim();
+      } else {
+        text = full;
+      }
+    }
+
+    return { speaker, text };
+  }
+
+  // Track last-seen caption to avoid re-sending identical lines
+  let lastCaptionKey = '';
+
+  function processCaptionMutations(container) {
+    const items = extractCaptionItems(container);
+
+    items.forEach((item) => {
+      const { speaker, text } = extractSpeakerText(item);
+      if (!text || text.length < 2) return;
+
+      const key = `${speaker}:${text}`;
+      if (key === lastCaptionKey) return;
+      lastCaptionKey = key;
+
+      const lang = detectLanguage(text);
+      monitor.send('caption', {
+        meetingId,
+        speaker: speaker || 'Unknown',
+        text,
+        lang,
+        ts: Date.now(),
+      });
+    });
+  }
+
+  function startCaptionMonitoring() {
+    if (captionObserver) return; // already running
+
+    const container = findCaptionContainer();
+    if (!container) {
+      // Retry in 3s — captions may not be active yet
+      setTimeout(() => {
+        if (captionsEnabled && meetingActive) startCaptionMonitoring();
+      }, 3000);
+      return;
+    }
+
+    captionObserver = new MutationObserver(() => processCaptionMutations(container));
+    captionObserver.observe(container, { childList: true, subtree: true, characterData: true });
+
+    // Process any already-visible captions
+    processCaptionMutations(container);
+  }
+
+  function stopCaptionMonitoring() {
+    if (captionObserver) {
+      captionObserver.disconnect();
+      captionObserver = null;
+    }
+    lastCaptionKey = '';
+  }
+
+  // ─── Listen for opt-in approval from service worker ───────────────────────
+
+  chrome.runtime.onMessage.addListener((message) => {
+    if (message.type === 'MEETING_CAPTIONS_ENABLED' && message.source === 'gmeet') {
+      captionsEnabled = true;
+      if (meetingActive) startCaptionMonitoring();
+    }
+    if (message.type === 'MEETING_CAPTIONS_DISABLED' && message.source === 'gmeet') {
+      captionsEnabled = false;
+      stopCaptionMonitoring();
+    }
+  });
+
+  // ─── Meeting State Detection ───────────────────────────────────────────────
+
+  const sendMeetingState = monitor.debounce(() => {
+    const inMeeting = isInMeeting();
+    const participants = getParticipants();
+    const title = getMeetingTitle();
+
+    if (monitor.hasChanged('meet_state', { inMeeting, participantCount: participants.length })) {
+      if (inMeeting && !meetingActive) {
+        meetingActive = true;
+        meetingId = `gmeet_${Date.now()}`;
+
+        // Step 1: Notify that a meeting was detected — service worker shows opt-in prompt
+        monitor.send('meeting_detected', {
+          platform: 'google_meet',
+          title,
+          participants,
+          meetingId,
+          url: location.href,
+        });
+
+        // Step 2: Send formal meeting_started event for recording
+        monitor.send('meeting_started', {
+          platform: 'google_meet',
+          title,
+          participants,
+          meetingId,
+          url: location.href,
+          ts: Date.now(),
+        });
+
+        // Caption monitoring starts only if opt-in was already given
+        if (captionsEnabled) startCaptionMonitoring();
+      } else if (!inMeeting && meetingActive) {
+        meetingActive = false;
+        stopCaptionMonitoring();
+
+        monitor.send('meeting_ended', {
+          platform: 'google_meet',
+          meetingId,
+          url: location.href,
+          ts: Date.now(),
+        });
+
+        meetingId = null;
+        captionsEnabled = false;
+      } else if (inMeeting && monitor.hasChanged('meet_participants', participants.length)) {
+        monitor.send('GMEET_PARTICIPANT_UPDATE', {
+          participantCount: participants.length,
+          participants,
+          url: location.href,
+        });
+      }
+    }
+  }, 3000);
+
+  // Watch body for DOM changes that indicate meeting state transitions
+  monitor.watch('body', sendMeetingState, {
+    observeId: 'meet_body',
+    childList: true,
+    subtree: false,
+  });
+
+  sendMeetingState();
+})();

--- a/extension/content/jira.js
+++ b/extension/content/jira.js
@@ -1,0 +1,51 @@
+/**
+ * Orchestra Twin Bridge — Jira (Atlassian) Content Script
+ */
+
+(() => {
+  if (window.__TwinJiraLoaded) return;
+  window.__TwinJiraLoaded = true;
+
+  const monitor = new TwinMonitor('jira');
+
+  const sendPageContext = monitor.debounce(() => {
+    const path = location.pathname;
+
+    // Issue page: /browse/PROJ-123
+    const issueMatch = path.match(/\/browse\/([A-Z]+-\d+)/);
+    if (issueMatch) {
+      const issueKey = issueMatch[1];
+      const title =
+        document
+          .querySelector('[data-testid="issue.views.issue-base.foundation.summary.heading"]')
+          ?.textContent?.trim() || document.title;
+      const statusEl = document.querySelector(
+        '[data-testid="issue.views.issue-base.foundation.status.status-field-wrapper"]',
+      );
+      const status = statusEl?.textContent?.trim();
+
+      if (monitor.hasChanged('jira_issue', issueKey)) {
+        monitor.send('JIRA_ISSUE_VIEWED', { issueKey, title, status, url: location.href });
+      }
+      return;
+    }
+
+    // Board page
+    if (path.includes('/boards')) {
+      const cards = document.querySelectorAll('[data-testid="platform-board-kit.ui.card.card"]');
+      if (monitor.hasChanged('jira_board', cards.length)) {
+        monitor.send('JIRA_BOARD_VIEWED', { cardCount: cards.length, url: location.href });
+      }
+    }
+  }, 1500);
+
+  // Navigation
+  const origPushState = history.pushState.bind(history);
+  history.pushState = function (...args) {
+    origPushState(...args);
+    setTimeout(sendPageContext, 800);
+  };
+  window.addEventListener('popstate', () => setTimeout(sendPageContext, 800));
+
+  sendPageContext();
+})();

--- a/extension/content/linear.js
+++ b/extension/content/linear.js
@@ -1,0 +1,50 @@
+/**
+ * Orchestra Twin Bridge — Linear Content Script
+ */
+
+(() => {
+  if (window.__TwinLinearLoaded) return;
+  window.__TwinLinearLoaded = true;
+
+  const monitor = new TwinMonitor('linear');
+
+  const sendInboxSummary = monitor.debounce(() => {
+    const inboxItems = document.querySelectorAll("[data-testid='inbox-item']");
+    const countEl = document.querySelector("[data-testid='inbox-count']");
+    const count = countEl
+      ? parseInt(countEl.textContent, 10) || inboxItems.length
+      : inboxItems.length;
+
+    if (monitor.hasChanged('linear_inbox', count)) {
+      monitor.send('LINEAR_INBOX_COUNT', { count, url: location.href });
+    }
+  }, 2000);
+
+  const sendIssueContext = monitor.debounce(() => {
+    const path = location.pathname;
+    const issueMatch = path.match(/\/issue\/([A-Z]+-\d+)/);
+    if (issueMatch) {
+      const issueId = issueMatch[1];
+      const title = document.title.replace(' - Linear', '').trim();
+      monitor.send('LINEAR_ISSUE_VIEWED', { issueId, title, url: location.href });
+    }
+  }, 1000);
+
+  monitor.watch('body', sendInboxSummary, {
+    observeId: 'inbox',
+    childList: true,
+    subtree: false,
+  });
+
+  const origPushState = history.pushState.bind(history);
+  history.pushState = function (...args) {
+    origPushState(...args);
+    setTimeout(() => {
+      sendInboxSummary();
+      sendIssueContext();
+    }, 600);
+  };
+
+  sendInboxSummary();
+  sendIssueContext();
+})();

--- a/extension/content/openai-usage.js
+++ b/extension/content/openai-usage.js
@@ -1,0 +1,76 @@
+/**
+ * Orchestra Twin Bridge — OpenAI Platform Usage Content Script
+ */
+
+(() => {
+  if (window.__TwinOpenAIUsageLoaded) return;
+  window.__TwinOpenAIUsageLoaded = true;
+
+  // Only run on usage/billing pages
+  if (!location.pathname.includes('/usage') && !location.pathname.includes('/billing')) return;
+
+  const monitor = new TwinMonitor('openai');
+
+  const SEL = {
+    totalCost:
+      '[data-testid="usage-total-cost"], .usage-total-cost, [class*="total-cost"], [class*="monthly-total"]',
+    dailyRows: '[data-testid="daily-usage-row"], .daily-usage-row, table tbody tr',
+    apiCallCount: '[data-testid="api-call-count"], [class*="api-calls"], [class*="request-count"]',
+    periodLabel: '[data-testid="billing-period"], [class*="billing-period"]',
+    modelRows: '[data-testid="model-usage-row"], [class*="model-row"]',
+    creditBalance:
+      '[data-testid="credit-balance"], [class*="credit-balance"], [class*="credits-remaining"]',
+  };
+
+  const parseCost = (text) => {
+    if (!text) return null;
+    const match = text.replace(/,/g, '').match(/[\d.]+/);
+    return match ? parseFloat(match[0]) : null;
+  };
+
+  const sendUsageUpdate = monitor.debounce(() => {
+    const totalEl = document.querySelector(SEL.totalCost);
+    const periodEl = document.querySelector(SEL.periodLabel);
+    const apiEl = document.querySelector(SEL.apiCallCount);
+    const creditEl = document.querySelector(SEL.creditBalance);
+
+    // Compute daily average from visible rows
+    const dailyRows = document.querySelectorAll(SEL.dailyRows);
+    const dailyCosts = Array.from(dailyRows)
+      .map((row) => {
+        const cells = row.querySelectorAll('td');
+        return parseCost(cells[cells.length - 1]?.textContent);
+      })
+      .filter((v) => v !== null);
+    const dailyAvg =
+      dailyCosts.length > 0 ? dailyCosts.reduce((a, b) => a + b, 0) / dailyCosts.length : null;
+
+    const payload = {
+      total: parseCost(totalEl?.textContent),
+      daily_avg: dailyAvg ? parseFloat(dailyAvg.toFixed(4)) : null,
+      api_calls: parseCost(apiEl?.textContent),
+      credit_balance: parseCost(creditEl?.textContent),
+      period: periodEl?.textContent?.trim() || null,
+      url: location.href,
+    };
+
+    if (monitor.hasChanged('openai_usage', payload)) {
+      monitor.send('cost_update', { source: 'openai', type: 'cost_update', data: payload });
+    }
+  }, 2000);
+
+  monitor.watch('[data-testid="usage-container"], .usage-container, main', sendUsageUpdate, {
+    observeId: 'usage-main',
+    childList: true,
+    subtree: true,
+  });
+
+  // SPA navigation
+  const origPushState = history.pushState.bind(history);
+  history.pushState = function (...args) {
+    origPushState(...args);
+    setTimeout(sendUsageUpdate, 600);
+  };
+
+  sendUsageUpdate();
+})();

--- a/extension/content/perplexity-usage.js
+++ b/extension/content/perplexity-usage.js
@@ -1,0 +1,75 @@
+/**
+ * Orchestra Twin Bridge — Perplexity.ai Usage Content Script
+ */
+
+(() => {
+  if (window.__TwinPerplexityUsageLoaded) return;
+  window.__TwinPerplexityUsageLoaded = true;
+
+  // Only run on settings/account pages
+  if (!location.pathname.includes('/settings') && !location.pathname.includes('/account')) return;
+
+  const monitor = new TwinMonitor('perplexity');
+
+  const SEL = {
+    settingsContainer: '[data-testid="settings-container"], [class*="settings-container"], main',
+    planBadge: '[data-testid="plan-name"], [class*="plan-name"], [class*="subscription-plan"]',
+    queriesUsed:
+      '[data-testid="queries-used"], [class*="queries-used"], [class*="pro-queries-used"]',
+    queriesRemaining:
+      '[data-testid="queries-remaining"], [class*="queries-remaining"], [class*="pro-queries-left"]',
+    renewalDate: '[data-testid="renewal-date"], [class*="renewal-date"], [class*="next-renewal"]',
+    usageBar: '[data-testid="usage-progress"], [class*="usage-progress"], [role="progressbar"]',
+  };
+
+  const parseNumber = (text) => {
+    if (!text) return null;
+    const match = text.replace(/,/g, '').match(/[\d.]+/);
+    return match ? parseFloat(match[0]) : null;
+  };
+
+  const sendUsageUpdate = monitor.debounce(() => {
+    const planEl = document.querySelector(SEL.planBadge);
+    const usedEl = document.querySelector(SEL.queriesUsed);
+    const remainingEl = document.querySelector(SEL.queriesRemaining);
+    const renewalEl = document.querySelector(SEL.renewalDate);
+    const barEl = document.querySelector(SEL.usageBar);
+
+    // Try reading usage from progress bar aria attributes as fallback
+    const barValue = barEl
+      ? parseNumber(barEl.getAttribute('aria-valuenow') || barEl.getAttribute('value'))
+      : null;
+    const barMax = barEl
+      ? parseNumber(barEl.getAttribute('aria-valuemax') || barEl.getAttribute('max'))
+      : null;
+
+    const payload = {
+      plan: planEl?.textContent?.trim() || null,
+      queries_used: parseNumber(usedEl?.textContent) ?? barValue,
+      queries_remaining:
+        parseNumber(remainingEl?.textContent) ??
+        (barMax && barValue !== null ? barMax - barValue : null),
+      renewal_date: renewalEl?.textContent?.trim() || null,
+      url: location.href,
+    };
+
+    if (monitor.hasChanged('perplexity_usage', payload)) {
+      monitor.send('cost_update', { source: 'perplexity', type: 'cost_update', data: payload });
+    }
+  }, 2000);
+
+  monitor.watch(SEL.settingsContainer, sendUsageUpdate, {
+    observeId: 'settings-main',
+    childList: true,
+    subtree: true,
+  });
+
+  // SPA navigation
+  const origPushState = history.pushState.bind(history);
+  history.pushState = function (...args) {
+    origPushState(...args);
+    setTimeout(sendUsageUpdate, 600);
+  };
+
+  sendUsageUpdate();
+})();

--- a/extension/content/shared/language.js
+++ b/extension/content/shared/language.js
@@ -1,0 +1,92 @@
+/**
+ * Orchestra Twin Bridge — Language Detector
+ *
+ * Detects whether text is Arabic, English, or mixed.
+ * Used by content scripts to tag events for proper routing/processing.
+ */
+
+// Prevent double-injection
+if (typeof window.__TwinLanguageLoaded === 'undefined') {
+  window.__TwinLanguageLoaded = true;
+
+  /**
+   * Unicode ranges for language detection.
+   */
+  const RANGES = {
+    // Arabic and extended Arabic blocks
+    arabic: [
+      [0x0600, 0x06ff], // Arabic
+      [0x0750, 0x077f], // Arabic Supplement
+      [0x08a0, 0x08ff], // Arabic Extended-A
+      [0xfb50, 0xfdff], // Arabic Presentation Forms-A
+      [0xfe70, 0xfeff], // Arabic Presentation Forms-B
+    ],
+  };
+
+  /**
+   * Check if a char code falls within Arabic ranges.
+   * @param {number} code
+   * @returns {boolean}
+   */
+  function isArabicChar(code) {
+    return RANGES.arabic.some(([start, end]) => code >= start && code <= end);
+  }
+
+  /**
+   * Detect the primary language of a text string.
+   *
+   * @param {string} text
+   * @returns {'ar' | 'en' | 'mixed' | 'unknown'}
+   */
+  function detectLanguage(text) {
+    if (!text || typeof text !== 'string') return 'unknown';
+
+    // Strip whitespace, numbers, punctuation — count only letter characters
+    const chars = text.split('').filter((c) => /\p{L}/u.test(c));
+    if (chars.length === 0) return 'unknown';
+
+    let arabicCount = 0;
+
+    for (const char of chars) {
+      const code = char.charCodeAt(0);
+      if (isArabicChar(code)) arabicCount++;
+    }
+
+    const arabicRatio = arabicCount / chars.length;
+
+    // Classification thresholds
+    if (arabicRatio >= 0.9) return 'ar';
+    if (arabicRatio <= 0.1) return 'en';
+    return 'mixed';
+  }
+
+  /**
+   * Get a breakdown of language distribution in text.
+   * @param {string} text
+   * @returns {{ lang: string, arabicRatio: number, arabicChars: number, totalChars: number }}
+   */
+  function analyzeLanguage(text) {
+    if (!text || typeof text !== 'string') {
+      return { lang: 'unknown', arabicRatio: 0, arabicChars: 0, totalChars: 0 };
+    }
+
+    const chars = text.split('').filter((c) => /\p{L}/u.test(c));
+    let arabicCount = 0;
+
+    for (const char of chars) {
+      if (isArabicChar(char.charCodeAt(0))) arabicCount++;
+    }
+
+    const arabicRatio = chars.length > 0 ? arabicCount / chars.length : 0;
+
+    return {
+      lang: detectLanguage(text),
+      arabicRatio: Math.round(arabicRatio * 100) / 100,
+      arabicChars: arabicCount,
+      totalChars: chars.length,
+    };
+  }
+
+  // Expose globally
+  window.TwinLanguage = { detectLanguage, analyzeLanguage, isArabicChar };
+}

--- a/extension/content/shared/messenger.js
+++ b/extension/content/shared/messenger.js
@@ -1,0 +1,59 @@
+/**
+ * Orchestra Twin Bridge — Messenger
+ *
+ * Thin wrapper around chrome.runtime.sendMessage with:
+ * - Error handling (handles disconnected service worker gracefully)
+ * - Optional response callback
+ * - Debug logging
+ */
+
+// Prevent double-injection
+if (typeof window.__TwinMessengerLoaded === 'undefined') {
+  window.__TwinMessengerLoaded = true;
+
+  window.TwinMessenger = {
+    /**
+     * Send a message to the service worker.
+     * @param {object}   message  — Message payload (must include `type`)
+     * @param {Function} [onResponse] — Optional response callback
+     * @returns {Promise<any>}
+     */
+    send(message, onResponse) {
+      return new Promise((resolve, reject) => {
+        try {
+          chrome.runtime.sendMessage(message, (response) => {
+            const err = chrome.runtime.lastError;
+
+            if (err) {
+              // "Could not establish connection" is expected when SW is sleeping
+              if (!err.message?.includes('Could not establish connection')) {
+                console.warn('[TwinMessenger] Send error:', err.message);
+              }
+              resolve(null);
+              return;
+            }
+
+            if (onResponse) onResponse(response);
+            resolve(response);
+          });
+        } catch (err) {
+          // Extension context may be invalidated after update/reload
+          if (!err.message?.includes('Extension context invalidated')) {
+            console.error('[TwinMessenger] Fatal send error:', err);
+          }
+          resolve(null);
+        }
+      });
+    },
+
+    /**
+     * Send a typed event from a content script.
+     * @param {string} source    — Service name (e.g. 'gmail')
+     * @param {string} type      — Event type
+     * @param {object} data      — Event data
+     */
+    event(source, type, data = {}) {
+      return this.send({ type, source, data, timestamp: Date.now() });
+    },
+  };
+}

--- a/extension/content/shared/observer.js
+++ b/extension/content/shared/observer.js
@@ -1,0 +1,246 @@
+/**
+ * Orchestra Twin Bridge — TwinMonitor
+ *
+ * Base class for all content scripts. Provides:
+ * - send(type, data)     — emit events to the service worker
+ * - watch(selector, cb)  — observe DOM changes on a selector
+ * - debounce(fn, ms)     — debounce wrapper
+ * - lastState            — store previous state for change detection
+ */
+
+// Prevent double-injection
+if (typeof window.__TwinMonitorLoaded === 'undefined') {
+  window.__TwinMonitorLoaded = true;
+
+  class TwinMonitor {
+    /**
+     * @param {string} source — Service identifier (e.g. 'gmail', 'slack')
+     */
+    constructor(source) {
+      this.source = source;
+      this.lastState = {};
+      this._observers = new Map();
+      this._retryTimers = new Map();
+      this._privacyMode = false;
+      this._enabled = false; // stays false until enabledOrigins check passes
+
+      // Load privacy mode + enabled state once
+      chrome.storage.local.get(
+        ['privacyMode', 'enabledOrigins'],
+        ({ privacyMode, enabledOrigins }) => {
+          this._privacyMode = !!privacyMode;
+          this._enabled = this._hostIsEnabled(enabledOrigins || []);
+        },
+      );
+
+      // React to setting changes live
+      chrome.storage.onChanged.addListener((changes, area) => {
+        if (area !== 'local') return;
+        if (changes.privacyMode !== undefined) {
+          this._privacyMode = !!changes.privacyMode.newValue;
+        }
+        if (changes.enabledOrigins !== undefined) {
+          const wasEnabled = this._enabled;
+          this._enabled = this._hostIsEnabled(changes.enabledOrigins.newValue || []);
+          // If disabled while running, tear down all observers
+          if (wasEnabled && !this._enabled) this.destroy();
+        }
+      });
+    }
+
+    /**
+     * Check whether the current page's hostname is covered by any of the
+     * user-enabled origin patterns (e.g. "*://linear.app/*").
+     * @private
+     */
+    _hostIsEnabled(enabledOrigins) {
+      const host = window.location.hostname;
+      return enabledOrigins.some((pattern) => {
+        // Strip protocol wildcard and path wildcard: "*://foo.com/*" → "foo.com"
+        const hostPart = pattern.replace(/^\*?:\/\//, '').replace(/\/.*$/, '');
+        if (hostPart.startsWith('*.')) {
+          return host.endsWith(hostPart.slice(1)); // *.atlassian.net → .atlassian.net
+        }
+        return host === hostPart;
+      });
+    }
+
+    /**
+     * Send an event to the service worker for forwarding to the Twin server.
+     * @param {string} type  — Event type (e.g. 'NEW_MESSAGE', 'UNREAD_COUNT')
+     * @param {object} data  — Payload data
+     */
+    send(type, data) {
+      if (!this._enabled) return; // user hasn't enabled this domain
+      if (this._privacyMode) {
+        // In privacy mode, send only metadata — no content
+        data = this._sanitize(data);
+      }
+
+      const message = {
+        type,
+        source: this.source,
+        data,
+        timestamp: Date.now(),
+      };
+
+      chrome.runtime.sendMessage(message).catch((err) => {
+        // Service worker may be inactive — this is expected
+        if (!err.message?.includes('Could not establish connection')) {
+          console.warn(`[TwinMonitor:${this.source}] Send failed:`, err.message);
+        }
+      });
+    }
+
+    /**
+     * Watch a DOM selector with MutationObserver.
+     * Auto-retries every 2s if element not found (up to maxRetries).
+     *
+     * @param {string}   selector   — CSS selector
+     * @param {Function} callback   — Called with (element, mutation) on change
+     * @param {object}   options
+     * @param {string}   options.observeId   — Unique ID for this watcher (for cleanup)
+     * @param {boolean}  options.childList   — Watch child additions/removals (default: true)
+     * @param {boolean}  options.subtree     — Watch all descendants (default: false)
+     * @param {boolean}  options.attributes  — Watch attribute changes (default: false)
+     * @param {string}   options.attributeFilter — Filter to specific attributes
+     * @param {boolean}  options.characterData   — Watch text changes (default: false)
+     * @param {number}   options.maxRetries  — Max retry attempts before giving up (default: 30)
+     */
+    watch(selector, callback, options = {}) {
+      const {
+        observeId = selector,
+        childList = true,
+        subtree = false,
+        attributes = false,
+        attributeFilter,
+        characterData = false,
+        maxRetries = 30,
+      } = options;
+
+      let retryCount = 0;
+
+      const setup = () => {
+        const el = document.querySelector(selector);
+
+        if (!el) {
+          retryCount++;
+          if (retryCount > maxRetries) {
+            console.warn(
+              `[TwinMonitor:${this.source}] Element not found after ${maxRetries} retries: ${selector}`,
+            );
+            return;
+          }
+          const timer = setTimeout(setup, 2000);
+          this._retryTimers.set(observeId, timer);
+          return;
+        }
+
+        // Clear any pending retry
+        const pending = this._retryTimers.get(observeId);
+        if (pending) {
+          clearTimeout(pending);
+          this._retryTimers.delete(observeId);
+        }
+
+        // Disconnect existing observer for this ID
+        this.unwatch(observeId);
+
+        const observerOptions = { childList, subtree, attributes, characterData };
+        if (attributeFilter) observerOptions.attributeFilter = attributeFilter;
+
+        const observer = new MutationObserver((mutations) => {
+          mutations.forEach((mutation) => {
+            try {
+              callback(el, mutation);
+            } catch (err) {
+              console.error(`[TwinMonitor:${this.source}] Watch callback error:`, err);
+            }
+          });
+        });
+
+        observer.observe(el, observerOptions);
+        this._observers.set(observeId, observer);
+
+        // Trigger initial callback with current state
+        try {
+          callback(el, null);
+        } catch (err) {
+          console.error(`[TwinMonitor:${this.source}] Initial callback error:`, err);
+        }
+      };
+
+      setup();
+    }
+
+    /**
+     * Stop watching a selector.
+     * @param {string} observeId
+     */
+    unwatch(observeId) {
+      const observer = this._observers.get(observeId);
+      if (observer) {
+        observer.disconnect();
+        this._observers.delete(observeId);
+      }
+    }
+
+    /**
+     * Stop all observers and clean up.
+     */
+    destroy() {
+      this._observers.forEach((observer) => observer.disconnect());
+      this._observers.clear();
+      this._retryTimers.forEach((timer) => clearTimeout(timer));
+      this._retryTimers.clear();
+    }
+
+    /**
+     * Debounce a function call.
+     * @param {Function} fn
+     * @param {number}   ms — Delay in milliseconds (default: 2000)
+     * @returns {Function}
+     */
+    debounce(fn, ms = 2000) {
+      let timer = null;
+      return (...args) => {
+        clearTimeout(timer);
+        timer = setTimeout(() => fn.apply(this, args), ms);
+      };
+    }
+
+    /**
+     * Check if a value has changed from lastState.
+     * @param {string} key
+     * @param {*}      value
+     * @returns {boolean}
+     */
+    hasChanged(key, value) {
+      const prev = this.lastState[key];
+      const changed = JSON.stringify(prev) !== JSON.stringify(value);
+      if (changed) this.lastState[key] = value;
+      return changed;
+    }
+
+    /**
+     * Sanitize data for privacy mode — strip content, keep counts/flags.
+     * @private
+     */
+    _sanitize(data) {
+      if (typeof data !== 'object' || data === null) return {};
+
+      const sanitized = {};
+      for (const [key, value] of Object.entries(data)) {
+        if (typeof value === 'number') sanitized[key] = value;
+        else if (typeof value === 'boolean') sanitized[key] = value;
+        else if (key.endsWith('Count') || key.endsWith('count')) sanitized[key] = value;
+        else if (key === 'timestamp' || key === 'url') sanitized[key] = value;
+        // Strip string content (names, messages, etc.)
+      }
+      return sanitized;
+    }
+  }
+
+  // Expose globally for content scripts
+  window.TwinMonitor = TwinMonitor;
+}

--- a/extension/content/slack.js
+++ b/extension/content/slack.js
@@ -1,0 +1,76 @@
+/**
+ * Orchestra Twin Bridge — Slack Content Script
+ */
+
+(() => {
+  if (window.__TwinSlackLoaded) return;
+  window.__TwinSlackLoaded = true;
+
+  const monitor = new TwinMonitor('slack');
+
+  const SEL = {
+    unreadChannels: '.p-channel_sidebar__channel--unread',
+    mentionBadge: '.p-channel_sidebar__badge--mention',
+    messageList: "[data-qa='virtual-list-scroll-container']",
+    message: "[data-qa='message_content']",
+    senderName: "[data-qa='message_sender_name']",
+    typingIndicator: "[data-qa='typing_indicator']",
+  };
+
+  // ─── Unread Summary ────────────────────────────────────────────────────────
+
+  const sendUnreadSummary = monitor.debounce(() => {
+    const unreadChannels = document.querySelectorAll(SEL.unreadChannels);
+    const mentions = document.querySelectorAll(SEL.mentionBadge);
+    const mentionCount = Array.from(mentions).reduce((acc, el) => {
+      return acc + (parseInt(el.textContent, 10) || 0);
+    }, 0);
+
+    const summary = {
+      unreadChannelCount: unreadChannels.length,
+      mentionCount,
+    };
+
+    if (monitor.hasChanged('unreadSummary', summary)) {
+      monitor.send('SLACK_UNREAD_SUMMARY', summary);
+    }
+  }, 1500);
+
+  // ─── New Message Detection ─────────────────────────────────────────────────
+
+  const sendNewMessage = monitor.debounce(() => {
+    const messages = document.querySelectorAll(SEL.message);
+    const last = messages[messages.length - 1];
+    if (!last) return;
+
+    const sender = last
+      .closest('[data-qa="message_container"]')
+      ?.querySelector(SEL.senderName)
+      ?.textContent?.trim();
+    const text = last.textContent?.trim()?.slice(0, 200);
+    const lang = TwinLanguage.detectLanguage(text || '');
+
+    const msgKey = `${sender}:${text?.slice(0, 40)}`;
+    if (monitor.hasChanged('lastMessage', msgKey)) {
+      monitor.send('SLACK_NEW_MESSAGE', { sender, text, lang, channel: location.pathname });
+    }
+  }, 2000);
+
+  // ─── Watchers ──────────────────────────────────────────────────────────────
+
+  monitor.watch('.p-channel_sidebar', sendUnreadSummary, {
+    observeId: 'sidebar',
+    childList: true,
+    subtree: true,
+    attributes: true,
+    attributeFilter: ['class'],
+  });
+
+  monitor.watch(SEL.messageList, sendNewMessage, {
+    observeId: 'messages',
+    childList: true,
+    subtree: false,
+  });
+
+  sendUnreadSummary();
+})();

--- a/extension/content/telegram.js
+++ b/extension/content/telegram.js
@@ -1,0 +1,35 @@
+/**
+ * Orchestra Twin Bridge — Telegram Web Content Script
+ */
+
+(() => {
+  if (window.__TwinTelegramLoaded) return;
+  window.__TwinTelegramLoaded = true;
+
+  const monitor = new TwinMonitor('telegram');
+
+  const sendUnreadSummary = monitor.debounce(() => {
+    const badges = document.querySelectorAll('.badge');
+    let totalUnread = 0;
+    badges.forEach((badge) => {
+      const n = parseInt(badge.textContent, 10);
+      if (!isNaN(n)) totalUnread += n;
+    });
+
+    if (monitor.hasChanged('tg_unread', totalUnread)) {
+      monitor.send('TELEGRAM_UNREAD_SUMMARY', {
+        totalUnread,
+        chatCount: badges.length,
+        url: location.href,
+      });
+    }
+  }, 2000);
+
+  monitor.watch('.chatlist-container', sendUnreadSummary, {
+    observeId: 'chatlist',
+    childList: true,
+    subtree: true,
+  });
+
+  sendUnreadSummary();
+})();

--- a/extension/content/twitter.js
+++ b/extension/content/twitter.js
@@ -1,0 +1,46 @@
+/**
+ * Orchestra Twin Bridge — X / Twitter Content Script
+ */
+
+(() => {
+  if (window.__TwinTwitterLoaded) return;
+  window.__TwinTwitterLoaded = true;
+
+  const monitor = new TwinMonitor('twitter');
+
+  const sendNotificationSummary = monitor.debounce(() => {
+    const notifBadge = document.querySelector(
+      "[data-testid='AppTabBar_Notifications_Link'] [data-testid='badge']",
+    );
+    const dmBadge = document.querySelector(
+      "[data-testid='AppTabBar_DirectMessage_Link'] [data-testid='badge']",
+    );
+
+    const notifCount = notifBadge ? parseInt(notifBadge.textContent, 10) || 0 : 0;
+    const dmCount = dmBadge ? parseInt(dmBadge.textContent, 10) || 0 : 0;
+
+    if (monitor.hasChanged('tw_counts', { notifCount, dmCount })) {
+      monitor.send('TWITTER_NOTIFICATION_SUMMARY', {
+        notificationCount: notifCount,
+        dmCount,
+        url: location.href,
+      });
+    }
+  }, 2000);
+
+  monitor.watch('[data-testid="AppTabBar_Home_Link"]', sendNotificationSummary, {
+    observeId: 'nav',
+    childList: true,
+    subtree: true,
+    attributes: true,
+  });
+
+  // SPA navigation
+  const origPushState = history.pushState.bind(history);
+  history.pushState = function (...args) {
+    origPushState(...args);
+    setTimeout(sendNotificationSummary, 500);
+  };
+
+  sendNotificationSummary();
+})();

--- a/extension/content/whatsapp.js
+++ b/extension/content/whatsapp.js
@@ -1,0 +1,46 @@
+/**
+ * Orchestra Twin Bridge — WhatsApp Web Content Script
+ */
+
+(() => {
+  if (window.__TwinWhatsAppLoaded) return;
+  window.__TwinWhatsAppLoaded = true;
+
+  const monitor = new TwinMonitor('whatsapp');
+
+  const SEL = {
+    chatList: "#pane-side [data-testid='chat-list']",
+    unreadBadge: "[data-testid='icon-unread-count']",
+    chatTitle: "[data-testid='cell-frame-title']",
+  };
+
+  const sendUnreadSummary = monitor.debounce(() => {
+    const badges = document.querySelectorAll(SEL.unreadBadge);
+    let totalUnread = 0;
+    const chats = [];
+
+    badges.forEach((badge) => {
+      const count = parseInt(badge.textContent, 10) || 1;
+      totalUnread += count;
+      const row = badge.closest('[data-testid="cell-frame-container"]');
+      const title = row?.querySelector(SEL.chatTitle)?.textContent?.trim();
+      if (title) chats.push({ title, count });
+    });
+
+    if (monitor.hasChanged('unreadTotal', totalUnread)) {
+      monitor.send('WHATSAPP_UNREAD_SUMMARY', {
+        totalUnread,
+        chatCount: chats.length,
+        chats: chats.slice(0, 5),
+      });
+    }
+  }, 2000);
+
+  monitor.watch(SEL.chatList, sendUnreadSummary, {
+    observeId: 'chatlist',
+    childList: true,
+    subtree: true,
+  });
+
+  sendUnreadSummary();
+})();

--- a/extension/content/x-premium.js
+++ b/extension/content/x-premium.js
@@ -1,0 +1,72 @@
+/**
+ * Orchestra Twin Bridge — X Premium Content Script
+ */
+
+(() => {
+  if (window.__TwinXPremiumLoaded) return;
+  window.__TwinXPremiumLoaded = true;
+
+  // Only run on premium/subscription settings pages
+  if (
+    !location.pathname.includes('/premium') &&
+    !location.pathname.includes('/settings/subscription')
+  )
+    return;
+
+  const monitor = new TwinMonitor('x-premium');
+
+  const SEL = {
+    premiumContainer: '[data-testid="premium-container"], [data-testid="subscriptions-page"], main',
+    planName: '[data-testid="premium-plan-name"], [data-testid="subscription-tier"]',
+    statusBadge: '[data-testid="subscription-status"], [data-testid="premium-status"]',
+    renewalDate: '[data-testid="renewal-date"], [data-testid="next-billing-date"]',
+    monthlyCost: '[data-testid="subscription-price"], [data-testid="billing-amount"]',
+    featureList: '[data-testid="premium-feature"], [data-testid="feature-item"]',
+  };
+
+  const parseCost = (text) => {
+    if (!text) return null;
+    const match = text.replace(/,/g, '').match(/[\d.]+/);
+    return match ? parseFloat(match[0]) : null;
+  };
+
+  const sendPremiumUpdate = monitor.debounce(() => {
+    const planEl = document.querySelector(SEL.planName);
+    const statusEl = document.querySelector(SEL.statusBadge);
+    const renewalEl = document.querySelector(SEL.renewalDate);
+    const costEl = document.querySelector(SEL.monthlyCost);
+
+    const payload = {
+      plan: planEl?.textContent?.trim() || null,
+      status: statusEl?.textContent?.trim() || null,
+      renewal_date: renewalEl?.textContent?.trim() || null,
+      monthly_cost: parseCost(costEl?.textContent),
+      url: location.href,
+    };
+
+    if (monitor.hasChanged('x_premium', payload)) {
+      monitor.send('cost_update', { source: 'x-premium', type: 'cost_update', data: payload });
+    }
+  }, 2000);
+
+  monitor.watch(SEL.premiumContainer, sendPremiumUpdate, {
+    observeId: 'premium-main',
+    childList: true,
+    subtree: true,
+  });
+
+  // SPA navigation (X is React-based)
+  const origPushState = history.pushState.bind(history);
+  history.pushState = function (...args) {
+    origPushState(...args);
+    // Re-check path after navigation
+    if (
+      location.pathname.includes('/premium') ||
+      location.pathname.includes('/settings/subscription')
+    ) {
+      setTimeout(sendPremiumUpdate, 600);
+    }
+  };
+
+  sendPremiumUpdate();
+})();

--- a/extension/content/zoom.js
+++ b/extension/content/zoom.js
@@ -1,0 +1,327 @@
+/**
+ * Orchestra Twin Bridge — Zoom Web Client Content Script
+ *
+ * Monitors:
+ * - Meeting start/end detection (Zoom web client at app.zoom.us)
+ * - Live closed caption extraction via MutationObserver
+ * - Participant list collection
+ *
+ * Privacy: all caption data stays local. Caption monitoring is OPT-IN.
+ * A meeting_detected event is sent first; the service worker handles the
+ * opt-in prompt before captions are forwarded.
+ */
+
+(() => {
+  if (window.__TwinZoomLoaded) return;
+  window.__TwinZoomLoaded = true;
+
+  const monitor = new TwinMonitor('zoom');
+  const detectLanguage = (text) => window.TwinLanguage?.detectLanguage(text) ?? 'unknown';
+
+  // ─── State ─────────────────────────────────────────────────────────────────
+
+  let meetingActive = false;
+  let captionsEnabled = false;
+  let captionObserver = null;
+  let meetingId = null;
+
+  // ─── Helpers ───────────────────────────────────────────────────────────────
+
+  function getMeetingTitle() {
+    return (
+      document.querySelector("[data-testid='meeting-title']")?.textContent?.trim() ||
+      document.querySelector('.meeting-title')?.textContent?.trim() ||
+      document.querySelector('[aria-label*="meeting"]')?.textContent?.trim() ||
+      document.title?.replace('Zoom Meeting', '').trim() ||
+      null
+    );
+  }
+
+  function getParticipants() {
+    const names = new Set();
+
+    // Participants panel list items
+    document.querySelectorAll("[data-testid='participant-panel'] li").forEach((li) => {
+      const name = li
+        .querySelector('[data-testid="participant-name"], .participant-name')
+        ?.textContent?.trim();
+      if (name) names.add(name);
+    });
+
+    // Video tiles in meeting view
+    document
+      .querySelectorAll('[data-testid="video-tile"] [data-testid="participant-name"]')
+      .forEach((el) => {
+        const name = el.textContent?.trim();
+        if (name) names.add(name);
+      });
+
+    // Fallback: attendee list items
+    document.querySelectorAll('.participants-list-item__name, .attendee-name').forEach((el) => {
+      const name = el.textContent?.trim();
+      if (name) names.add(name);
+    });
+
+    return [...names];
+  }
+
+  function isInMeeting() {
+    const path = location.pathname;
+    if (!path.includes('/meeting') && !path.includes('/wc/')) return false;
+
+    // Confirm meeting is actually active (not just the pre-join screen)
+    const hasVideo = !!document.querySelector('[data-testid="video-tile"], .video-tile');
+    const hasControls = !!document.querySelector(
+      "[data-testid='meeting-controls'], .meeting-controls, [data-testid='leave-btn']",
+    );
+    return hasVideo || hasControls;
+  }
+
+  // ─── Caption Monitoring ────────────────────────────────────────────────────
+
+  /**
+   * Zoom web client caption containers:
+   *   [data-testid='live-transcription']   — live transcript panel
+   *   .caption-container                   — classic caption overlay
+   *   [data-testid='closed-caption']       — closed caption container
+   *   .zmWebSDKCCContainer                 — Web SDK caption container
+   *
+   * Each item typically contains:
+   *   .transcript-speaker / [data-testid='speaker-name']  — speaker
+   *   .transcript-text / [data-testid='transcript-text']  — text
+   */
+  const CAPTION_CONTAINER_SELECTORS = [
+    "[data-testid='live-transcription']",
+    "[data-testid='closed-caption']",
+    '.caption-container',
+    '.zmWebSDKCCContainer',
+    '[class*="caption-container"]',
+    '[class*="transcript-container"]',
+  ];
+
+  const CAPTION_ITEM_SELECTORS = [
+    '.transcript-item',
+    '[data-testid="transcript-item"]',
+    '.caption-item',
+    '.cc-item',
+  ];
+
+  const SPEAKER_SELECTORS = [
+    '.transcript-speaker',
+    '[data-testid="speaker-name"]',
+    '.speaker-name',
+    '.cc-speaker',
+  ];
+
+  const TEXT_SELECTORS = [
+    '.transcript-text',
+    '[data-testid="transcript-text"]',
+    '.caption-text',
+    '.cc-text',
+  ];
+
+  function findCaptionContainer() {
+    for (const sel of CAPTION_CONTAINER_SELECTORS) {
+      const el = document.querySelector(sel);
+      if (el) return el;
+    }
+    return null;
+  }
+
+  function extractCaptionItems(container) {
+    for (const sel of CAPTION_ITEM_SELECTORS) {
+      const items = container.querySelectorAll(sel);
+      if (items.length > 0) return items;
+    }
+    return container.querySelectorAll(':scope > div');
+  }
+
+  function extractSpeakerText(item) {
+    let speaker = '';
+    let text = '';
+
+    for (const sel of SPEAKER_SELECTORS) {
+      const el = item.querySelector(sel);
+      if (el) {
+        speaker = el.textContent?.trim() ?? '';
+        break;
+      }
+    }
+
+    for (const sel of TEXT_SELECTORS) {
+      const el = item.querySelector(sel);
+      if (el) {
+        text = el.textContent?.trim() ?? '';
+        break;
+      }
+    }
+
+    // Fallback: split on colon for "Name: text" format
+    if (!text && !speaker) {
+      const full = item.textContent?.trim() ?? '';
+      const colonIdx = full.indexOf(':');
+      if (colonIdx > 0 && colonIdx < 40) {
+        speaker = full.slice(0, colonIdx).trim();
+        text = full.slice(colonIdx + 1).trim();
+      } else {
+        text = full;
+      }
+    }
+
+    return { speaker, text };
+  }
+
+  let lastCaptionKey = '';
+
+  function processCaptionMutations(container) {
+    const items = extractCaptionItems(container);
+
+    items.forEach((item) => {
+      const { speaker, text } = extractSpeakerText(item);
+      if (!text || text.length < 2) return;
+
+      const key = `${speaker}:${text}`;
+      if (key === lastCaptionKey) return;
+      lastCaptionKey = key;
+
+      const lang = detectLanguage(text);
+      monitor.send('caption', {
+        meetingId,
+        speaker: speaker || 'Unknown',
+        text,
+        lang,
+        ts: Date.now(),
+      });
+    });
+  }
+
+  function startCaptionMonitoring() {
+    if (captionObserver) return;
+
+    const container = findCaptionContainer();
+    if (!container) {
+      // Retry — captions panel may not have been opened yet
+      setTimeout(() => {
+        if (captionsEnabled && meetingActive) startCaptionMonitoring();
+      }, 3000);
+      return;
+    }
+
+    captionObserver = new MutationObserver(() => processCaptionMutations(container));
+    captionObserver.observe(container, { childList: true, subtree: true, characterData: true });
+
+    processCaptionMutations(container);
+  }
+
+  function stopCaptionMonitoring() {
+    if (captionObserver) {
+      captionObserver.disconnect();
+      captionObserver = null;
+    }
+    lastCaptionKey = '';
+  }
+
+  // ─── Listen for opt-in approval from service worker ───────────────────────
+
+  chrome.runtime.onMessage.addListener((message) => {
+    if (message.type === 'MEETING_CAPTIONS_ENABLED' && message.source === 'zoom') {
+      captionsEnabled = true;
+      if (meetingActive) startCaptionMonitoring();
+    }
+    if (message.type === 'MEETING_CAPTIONS_DISABLED' && message.source === 'zoom') {
+      captionsEnabled = false;
+      stopCaptionMonitoring();
+    }
+  });
+
+  // ─── Meeting State Detection ───────────────────────────────────────────────
+
+  const sendMeetingState = monitor.debounce(() => {
+    const inMeeting = isInMeeting();
+    const participants = getParticipants();
+    const title = getMeetingTitle();
+    const isRecording = !!document.querySelector(
+      "[data-testid='recording-status'], .recording-status",
+    );
+
+    if (monitor.hasChanged('zoom_meeting_active', inMeeting)) {
+      if (inMeeting && !meetingActive) {
+        meetingActive = true;
+        meetingId = `zoom_${Date.now()}`;
+
+        // Step 1: Notify that a meeting was detected — service worker shows opt-in prompt
+        monitor.send('meeting_detected', {
+          platform: 'zoom',
+          title,
+          participants,
+          meetingId,
+          url: location.href,
+        });
+
+        // Step 2: Formal meeting started event
+        monitor.send('meeting_started', {
+          platform: 'zoom',
+          title,
+          participants,
+          meetingId,
+          isRecording,
+          url: location.href,
+          ts: Date.now(),
+        });
+
+        if (captionsEnabled) startCaptionMonitoring();
+      } else if (!inMeeting && meetingActive) {
+        meetingActive = false;
+        stopCaptionMonitoring();
+
+        monitor.send('meeting_ended', {
+          platform: 'zoom',
+          meetingId,
+          url: location.href,
+          ts: Date.now(),
+        });
+
+        meetingId = null;
+        captionsEnabled = false;
+      } else if (inMeeting && monitor.hasChanged('zoom_participants', participants.length)) {
+        monitor.send('ZOOM_PARTICIPANT_UPDATE', {
+          participantCount: participants.length,
+          participants,
+          isRecording,
+          url: location.href,
+        });
+      }
+    }
+
+    // Upcoming meetings (home page)
+    if (!inMeeting) {
+      const upcomingMeetings = document.querySelectorAll(
+        "[data-testid='upcoming-meetings'] [data-testid='meeting-item']",
+      );
+      if (monitor.hasChanged('zoom_upcoming', upcomingMeetings.length)) {
+        monitor.send('ZOOM_UPCOMING_MEETINGS', {
+          count: upcomingMeetings.length,
+          url: location.href,
+        });
+      }
+    }
+  }, 2000);
+
+  // ─── SPA navigation handling ───────────────────────────────────────────────
+
+  const origPushState = history.pushState.bind(history);
+  history.pushState = function (...args) {
+    origPushState(...args);
+    setTimeout(sendMeetingState, 600);
+  };
+  window.addEventListener('popstate', () => setTimeout(sendMeetingState, 600));
+
+  // Watch for meeting UI mounting/unmounting
+  monitor.watch('body', sendMeetingState, {
+    observeId: 'zoom_body',
+    childList: true,
+    subtree: false,
+  });
+
+  sendMeetingState();
+})();

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -34,6 +34,179 @@
     "*://platform.openai.com/*",
     "*://perplexity.ai/*"
   ],
+  "content_scripts": [
+    {
+      "matches": ["*://mail.google.com/*"],
+      "js": [
+        "content/shared/messenger.js",
+        "content/shared/observer.js",
+        "content/shared/language.js",
+        "content/gmail.js"
+      ],
+      "run_at": "document_idle"
+    },
+    {
+      "matches": ["*://app.slack.com/*"],
+      "js": [
+        "content/shared/messenger.js",
+        "content/shared/observer.js",
+        "content/shared/language.js",
+        "content/slack.js"
+      ],
+      "run_at": "document_idle"
+    },
+    {
+      "matches": ["*://web.whatsapp.com/*"],
+      "js": [
+        "content/shared/messenger.js",
+        "content/shared/observer.js",
+        "content/shared/language.js",
+        "content/whatsapp.js"
+      ],
+      "run_at": "document_idle"
+    },
+    {
+      "matches": ["*://discord.com/*"],
+      "js": [
+        "content/shared/messenger.js",
+        "content/shared/observer.js",
+        "content/shared/language.js",
+        "content/discord.js"
+      ],
+      "run_at": "document_idle"
+    },
+    {
+      "matches": ["*://web.telegram.org/*"],
+      "js": [
+        "content/shared/messenger.js",
+        "content/shared/observer.js",
+        "content/shared/language.js",
+        "content/telegram.js"
+      ],
+      "run_at": "document_idle"
+    },
+    {
+      "matches": ["*://x.com/*"],
+      "js": [
+        "content/shared/messenger.js",
+        "content/shared/observer.js",
+        "content/shared/language.js",
+        "content/twitter.js",
+        "content/x-premium.js"
+      ],
+      "run_at": "document_idle"
+    },
+    {
+      "matches": ["*://github.com/*"],
+      "js": [
+        "content/shared/messenger.js",
+        "content/shared/observer.js",
+        "content/shared/language.js",
+        "content/github.js"
+      ],
+      "run_at": "document_idle"
+    },
+    {
+      "matches": ["*://linear.app/*"],
+      "js": [
+        "content/shared/messenger.js",
+        "content/shared/observer.js",
+        "content/shared/language.js",
+        "content/linear.js"
+      ],
+      "run_at": "document_idle"
+    },
+    {
+      "matches": ["*://*.atlassian.net/*"],
+      "js": [
+        "content/shared/messenger.js",
+        "content/shared/observer.js",
+        "content/shared/language.js",
+        "content/jira.js"
+      ],
+      "run_at": "document_idle"
+    },
+    {
+      "matches": ["*://calendar.google.com/*"],
+      "js": [
+        "content/shared/messenger.js",
+        "content/shared/observer.js",
+        "content/shared/language.js",
+        "content/gcal.js"
+      ],
+      "run_at": "document_idle"
+    },
+    {
+      "matches": ["*://app.cal.com/*"],
+      "js": [
+        "content/shared/messenger.js",
+        "content/shared/observer.js",
+        "content/shared/language.js",
+        "content/calcom.js"
+      ],
+      "run_at": "document_idle"
+    },
+    {
+      "matches": ["*://meet.google.com/*"],
+      "js": [
+        "content/shared/messenger.js",
+        "content/shared/observer.js",
+        "content/shared/language.js",
+        "content/gmeet.js"
+      ],
+      "run_at": "document_idle"
+    },
+    {
+      "matches": ["*://app.zoom.us/*"],
+      "js": [
+        "content/shared/messenger.js",
+        "content/shared/observer.js",
+        "content/shared/language.js",
+        "content/zoom.js"
+      ],
+      "run_at": "document_idle"
+    },
+    {
+      "matches": ["*://console.cloud.google.com/*"],
+      "js": [
+        "content/shared/messenger.js",
+        "content/shared/observer.js",
+        "content/shared/language.js",
+        "content/gcp-billing.js"
+      ],
+      "run_at": "document_idle"
+    },
+    {
+      "matches": ["*://claude.ai/*"],
+      "js": [
+        "content/shared/messenger.js",
+        "content/shared/observer.js",
+        "content/shared/language.js",
+        "content/claude-usage.js"
+      ],
+      "run_at": "document_idle"
+    },
+    {
+      "matches": ["*://platform.openai.com/*"],
+      "js": [
+        "content/shared/messenger.js",
+        "content/shared/observer.js",
+        "content/shared/language.js",
+        "content/openai-usage.js"
+      ],
+      "run_at": "document_idle"
+    },
+    {
+      "matches": ["*://perplexity.ai/*"],
+      "js": [
+        "content/shared/messenger.js",
+        "content/shared/observer.js",
+        "content/shared/language.js",
+        "content/perplexity-usage.js"
+      ],
+      "run_at": "document_idle"
+    }
+  ],
   "web_accessible_resources": [
     {
       "resources": ["offscreen/offscreen.html"],


### PR DESCRIPTION
Closes #13, #14, #15, #16, #17, #18, #19, #20, #21, #22, #23, #24, #25, #26, #27, #28, #29 in one batch — they share the same content-script harness pattern.

## Test plan
- [x] typecheck / lint / format:check — clean
- [ ] Manual: load extension, log into each platform, verify content scripts emit events visible in the desktop app's React UI

Carried verbatim from `orch/apps/twin-bridge/content/` so selectors track upstream behaviour. Future bug fixes will diverge per-platform as users report issues.