### PR TITLE
feat(tests, docs): real test suite + release-signing operator guide

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,27 @@ jobs:
       - name: Build desktop renderer + main
         run: npm -w @claude-twin/desktop run build
 
+  test:
+    name: test
+    runs-on: ubuntu-latest
+    needs: lint-typecheck
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci --workspaces --include-workspace-root
+
+      - name: Build mcp-server
+        run: npm -w @claude-twin/mcp-server run build
+
+      - name: Run tests
+        run: npm -w @claude-twin/mcp-server run test
+
   package-extension:
     name: extension zip
     runs-on: ubuntu-latest

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,0 +1,96 @@
+# Release guide
+
+This is the operator's checklist for cutting a real signed release. The release workflow at `.github/workflows/release.yml` runs on every `v*.*.*` tag push; this doc covers what secrets to set so it actually produces signed artifacts.
+
+> Until these secrets are configured, releases produce **unsigned** binaries. macOS will Gatekeeper-block them on first launch and Windows SmartScreen will warn users. The app still works once the user right-clicks → Open (mac) or clicks "Run anyway" (Windows), but it's a poor first-impression experience.
+
+## What gets built on a tag push
+
+| Artifact    | Path in Release                                    | Source              |
+| ----------- | -------------------------------------------------- | ------------------- |
+| macOS arm64 | `claude-twin-<ver>-arm64.dmg`                      | `desktop/dist/`     |
+| macOS x64   | `claude-twin-<ver>.dmg`                            | `desktop/dist/`     |
+| Windows x64 | `claude-twin-<ver>-setup.exe`                      | `desktop/dist/`     |
+| Linux x64   | `claude-twin-<ver>.AppImage`                       | `desktop/dist/`     |
+| Update feed | `latest-mac.yml`, `latest.yml`, `latest-linux.yml` | electron-updater    |
+| Extension   | `claude-twin-extension-v<ver>.zip`                 | `extension/` zipped |
+| MCP server  | `@claude-twin/mcp-server@<ver>` on npm             | `mcp-server/`       |
+
+## Required secrets
+
+Set in **Settings → Secrets and variables → Actions** on the repo.
+
+### macOS code signing + notarization
+
+| Secret                        | What it is                                                           | How to get it                                                             |
+| ----------------------------- | -------------------------------------------------------------------- | ------------------------------------------------------------------------- |
+| `MAC_CSC_LINK`                | Base64-encoded `.p12` of your "Developer ID Application" certificate | See "Get a Developer ID cert" below                                       |
+| `MAC_CSC_KEY_PASSWORD`        | Password for the .p12                                                | You set it during export                                                  |
+| `APPLE_ID`                    | The Apple ID email tied to your developer account                    | from `id.apple.com`                                                       |
+| `APPLE_APP_SPECIFIC_PASSWORD` | App-specific password for that Apple ID                              | https://appleid.apple.com → Sign-In and Security → App-Specific Passwords |
+| `APPLE_TEAM_ID`               | Your developer team's 10-character team id                           | https://developer.apple.com/account → Membership                          |
+
+#### Get a Developer ID cert
+
+1. Sign in to [developer.apple.com](https://developer.apple.com/account) — needs a paid Developer Program membership (US$99/yr).
+2. Certificates → `+` → **Developer ID Application**.
+3. Generate a CSR with Keychain Access → Certificate Assistant → "Request a Certificate from a Certificate Authority" (saved to disk, no email).
+4. Upload the CSR; download the resulting `.cer`.
+5. Double-click to install in Keychain Access.
+6. In Keychain Access, find "Developer ID Application: Your Name (TEAMID)", expand it, right-click the private key, **Export**. Choose `.p12`, set a password.
+7. Base64-encode for GitHub: `base64 -i developer-id.p12 -o cert.p12.base64` → contents go into `MAC_CSC_LINK`.
+
+### Windows code signing
+
+| Secret                 | What it is                                             |
+| ---------------------- | ------------------------------------------------------ |
+| `WIN_CSC_LINK`         | Base64-encoded `.pfx` of your code-signing certificate |
+| `WIN_CSC_KEY_PASSWORD` | Password for the .pfx                                  |
+
+Buy a code-signing certificate from a trusted CA — DigiCert, Sectigo, SSL.com all sell EV certs ($300-500/yr) which avoid the SmartScreen "publisher unknown" warning. Standard OV certs ($75-150/yr) work but Microsoft will warn until enough installs accumulate reputation.
+
+The cert vendor will deliver a `.pfx`. Encode like macOS: `base64 -i cert.pfx -o cert.pfx.base64` → contents go into `WIN_CSC_LINK`.
+
+### npm publish
+
+| Secret      | What it is                                                        |
+| ----------- | ----------------------------------------------------------------- |
+| `NPM_TOKEN` | Automation token with publish access to `@claude-twin/mcp-server` |
+
+1. https://npmjs.com → your profile → Access Tokens → "Generate New Token" → **Automation** type.
+2. The release workflow uses npm provenance, so make sure your repo allows it: `npm publish --provenance` requires the workflow runs on a `pull_request` or `push` event with proper OIDC scopes (already configured in our workflow).
+
+## Cutting a release (once secrets are set)
+
+```sh
+# 1. Bump versions in lockstep
+for f in package.json desktop/package.json extension/package.json mcp-server/package.json plugin/package.json plugin/.claude-plugin/plugin.json vscode-extension/package.json; do
+  # use jq or your editor of choice; node will reject mismatched workspace deps
+  echo "bump $f"
+done
+
+# 2. Update CHANGELOG.md — promote `[Unreleased]` to `[<version>]`
+$EDITOR CHANGELOG.md
+
+# 3. Commit + tag + push
+git commit -am "chore: release v0.1.0"
+git tag v0.1.0
+git push origin main
+git push origin v0.1.0
+```
+
+The workflow takes ~25 minutes (mac-14 build is the slowest leg; cross-arch dmg + notarization).
+
+## After publish
+
+- Verify the GitHub Release page has all six artifacts attached.
+- Verify electron-updater feed is reachable: `curl -L https://github.com/fadymondy/claude-twin/releases/latest/download/latest-mac.yml`.
+- Verify npm: `npm view @claude-twin/mcp-server version` returns the new version.
+- Verify auto-update flow: install the previous version, launch, wait for the update prompt.
+
+## Failure modes
+
+- **Notarization fails (`Apple service error: ITMS-90000`)**: Apple ID password rotated, or app-specific password expired. Regenerate at appleid.apple.com.
+- **Windows SmartScreen still warns despite signing**: standard OV cert needs to build reputation. Either wait for ~50 successful installs, or upgrade to EV.
+- **`Cannot compute electron version from installed node modules`**: `electron` dep in `desktop/package.json` is using a range (`^33.x.y`). Pin to an exact version.
+- **`@claude-twin/mcp-server` publish fails with 403**: NPM_TOKEN doesn't have publish access, or 2FA isn't auto-token type.

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -18,7 +18,7 @@
     "dev": "tsc --build --watch",
     "start": "node dist/index.js",
     "typecheck": "tsc --build --dry",
-    "test": "node --test dist/**/*.test.js"
+    "test": "node --test --test-reporter=spec --enable-source-maps 'dist/**/*.test.js'"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.18.0",

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -18,7 +18,7 @@
     "dev": "tsc --build --watch",
     "start": "node dist/index.js",
     "typecheck": "tsc --build --dry",
-    "test": "node --test --test-reporter=spec --enable-source-maps 'dist/**/*.test.js'"
+    "test": "node --test --test-reporter=spec --enable-source-maps dist/bridge/ws-host.test.js dist/state/monitors.test.js"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.18.0",

--- a/mcp-server/src/bridge/ws-host.test.ts
+++ b/mcp-server/src/bridge/ws-host.test.ts
@@ -1,0 +1,248 @@
+/**
+ * WsBridge integration tests. Uses node:test (no extra deps).
+ *
+ * Strategy: spin up a real WsBridge on an ephemeral port, point a real
+ * `ws` client at it, and assert the wire protocol works.
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import WebSocket from 'ws';
+import {
+  BridgeNotConnectedError,
+  CommandFailedError,
+  CommandTimeoutError,
+  WsBridge,
+} from './ws-host.js';
+
+interface Bridged {
+  bridge: WsBridge;
+  url: string;
+  cleanup: () => Promise<void>;
+}
+
+async function startBridge(opts: { token?: string | null } = {}): Promise<Bridged> {
+  // Port 0 → kernel picks an unused port.
+  const bridge = new WsBridge({ port: 0, ...(opts.token !== undefined && { token: opts.token }) });
+  await bridge.start();
+  // After start, status().url reflects the configured port (0). We need the
+  // *actual* port — read it off the underlying http server.
+  const httpServer = (bridge as unknown as { httpServer: { address(): { port: number } } })
+    .httpServer;
+  const port = httpServer.address().port;
+  const url = `ws://127.0.0.1:${port}/twin`;
+  return {
+    bridge,
+    url,
+    cleanup: () => bridge.stop(),
+  };
+}
+
+function connect(url: string): Promise<WebSocket> {
+  return new Promise((resolve, reject) => {
+    const ws = new WebSocket(url);
+    ws.once('open', () => resolve(ws));
+    ws.once('error', reject);
+  });
+}
+
+function nextMessage<T = unknown>(ws: WebSocket): Promise<T> {
+  return new Promise((resolve) => {
+    ws.once('message', (raw) => resolve(JSON.parse(raw.toString())));
+  });
+}
+
+test('auth handshake succeeds with no token', async () => {
+  const { bridge, url, cleanup } = await startBridge();
+  try {
+    const ws = await connect(url);
+    ws.send(JSON.stringify({ type: 'auth', token: null, extension_id: 'test' }));
+    const reply = await nextMessage<{ type: string }>(ws);
+    assert.equal(reply.type, 'auth_ok');
+    // After ready, status reports authenticated
+    await new Promise((r) => setTimeout(r, 20));
+    const status = bridge.status();
+    assert.equal(status.authenticated, true);
+    assert.equal(status.extensionId, 'test');
+    ws.close();
+  } finally {
+    await cleanup();
+  }
+});
+
+test('auth fails when token mismatches', async () => {
+  const { url, cleanup } = await startBridge({ token: 'right' });
+  try {
+    const ws = await connect(url);
+    ws.send(JSON.stringify({ type: 'auth', token: 'wrong', extension_id: 'test' }));
+    const reply = await nextMessage<{ type: string; reason?: string }>(ws);
+    assert.equal(reply.type, 'auth_fail');
+    assert.equal(reply.reason, 'invalid token');
+  } finally {
+    await cleanup();
+  }
+});
+
+test('ping → pong', async () => {
+  const { url, cleanup } = await startBridge();
+  try {
+    const ws = await connect(url);
+    ws.send(JSON.stringify({ type: 'auth', token: null, extension_id: 't' }));
+    await nextMessage(ws); // auth_ok
+    ws.send(JSON.stringify({ type: 'ping' }));
+    const pong = await nextMessage<{ type: string }>(ws);
+    assert.equal(pong.type, 'pong');
+    ws.close();
+  } finally {
+    await cleanup();
+  }
+});
+
+test('sendCommand round-trips a result', async () => {
+  const { bridge, url, cleanup } = await startBridge();
+  try {
+    const ws = await connect(url);
+    ws.send(JSON.stringify({ type: 'auth', token: null, extension_id: 't' }));
+    await nextMessage(ws); // auth_ok
+
+    // Echo every command we receive.
+    ws.on('message', (raw) => {
+      const msg = JSON.parse(raw.toString());
+      if (msg.type === 'command') {
+        ws.send(JSON.stringify({ type: 'response', id: msg.id, result: { echo: msg.action } }));
+      }
+    });
+
+    const result = await bridge.sendCommand<{ echo: string }>('hello', { x: 1 });
+    assert.deepEqual(result, { echo: 'hello' });
+    ws.close();
+  } finally {
+    await cleanup();
+  }
+});
+
+test('sendCommand rejects with BridgeNotConnectedError when no client', async () => {
+  const { bridge, cleanup } = await startBridge();
+  try {
+    await assert.rejects(bridge.sendCommand('x', {}), BridgeNotConnectedError);
+  } finally {
+    await cleanup();
+  }
+});
+
+test('sendCommand rejects with CommandFailedError on error response', async () => {
+  const { bridge, url, cleanup } = await startBridge();
+  try {
+    const ws = await connect(url);
+    ws.send(JSON.stringify({ type: 'auth', token: null, extension_id: 't' }));
+    await nextMessage(ws);
+    ws.on('message', (raw) => {
+      const msg = JSON.parse(raw.toString());
+      if (msg.type === 'command') {
+        ws.send(
+          JSON.stringify({
+            type: 'response',
+            id: msg.id,
+            error: { message: 'boom', code: 'X' },
+          }),
+        );
+      }
+    });
+    await assert.rejects(bridge.sendCommand('boom', {}), (err: Error) => {
+      assert.ok(err instanceof CommandFailedError);
+      assert.match(err.message, /boom/);
+      return true;
+    });
+    ws.close();
+  } finally {
+    await cleanup();
+  }
+});
+
+test('sendCommand rejects with CommandTimeoutError when client is silent', async () => {
+  const { bridge, url, cleanup } = await startBridge();
+  try {
+    const ws = await connect(url);
+    ws.send(JSON.stringify({ type: 'auth', token: null, extension_id: 't' }));
+    await nextMessage(ws);
+    // Client never responds to commands — let the bridge time out.
+    await assert.rejects(bridge.sendCommand('slow', {}, { timeoutMs: 100 }), CommandTimeoutError);
+    ws.close();
+  } finally {
+    await cleanup();
+  }
+});
+
+test('all pending commands fail when client disconnects', async () => {
+  const { bridge, url, cleanup } = await startBridge();
+  try {
+    const ws = await connect(url);
+    ws.send(JSON.stringify({ type: 'auth', token: null, extension_id: 't' }));
+    await nextMessage(ws);
+    const inFlight = bridge.sendCommand('hang', {}, { timeoutMs: 5000 });
+    setTimeout(() => ws.close(), 30);
+    await assert.rejects(inFlight, BridgeNotConnectedError);
+  } finally {
+    await cleanup();
+  }
+});
+
+test("'ready' event fires after auth_ok", async () => {
+  const { bridge, url, cleanup } = await startBridge();
+  try {
+    const seen: string[] = [];
+    bridge.on('ready', (info: { extensionId: string | null }) => {
+      seen.push(info.extensionId ?? 'null');
+    });
+    const ws = await connect(url);
+    ws.send(JSON.stringify({ type: 'auth', token: null, extension_id: 'ext-42' }));
+    await nextMessage(ws);
+    // Ready is emitted synchronously after auth_ok — give a tick.
+    await new Promise((r) => setTimeout(r, 20));
+    assert.deepEqual(seen, ['ext-42']);
+    ws.close();
+  } finally {
+    await cleanup();
+  }
+});
+
+test('inbound event message reaches onEvent handler', async () => {
+  const { bridge, url, cleanup } = await startBridge();
+  try {
+    const got: { source: string; eventType: string }[] = [];
+    bridge.onEvent((evt) => got.push({ source: evt.source, eventType: evt.eventType }));
+
+    const ws = await connect(url);
+    ws.send(JSON.stringify({ type: 'auth', token: null, extension_id: 't' }));
+    await nextMessage(ws);
+    ws.send(
+      JSON.stringify({
+        type: 'event',
+        source: 'gmail',
+        eventType: 'GMAIL_UNREAD_COUNT',
+        data: { count: 3 },
+        timestamp: Date.now(),
+      }),
+    );
+    await new Promise((r) => setTimeout(r, 30));
+    assert.equal(got.length, 1);
+    assert.equal(got[0].source, 'gmail');
+    assert.equal(got[0].eventType, 'GMAIL_UNREAD_COUNT');
+    ws.close();
+  } finally {
+    await cleanup();
+  }
+});
+
+test('rejects non-loopback connections', async () => {
+  // Hard to actually drive from a non-loopback IP in a unit test, so we
+  // assert the behaviour via the path-rejection branch instead: a
+  // request to a path other than /twin must 404.
+  const { url, cleanup } = await startBridge();
+  try {
+    const wrongUrl = url.replace('/twin', '/elsewhere');
+    await assert.rejects(connect(wrongUrl), Error);
+  } finally {
+    await cleanup();
+  }
+});

--- a/mcp-server/src/state/monitors.test.ts
+++ b/mcp-server/src/state/monitors.test.ts
@@ -1,0 +1,125 @@
+/**
+ * MonitorRegistry tests. Uses a stub `WsBridge` that records sendCommand
+ * calls and lets us emit synthetic events.
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { EventEmitter } from 'node:events';
+import { MonitorRegistry, DEFAULT_REALTIME_SLUGS } from './monitors.js';
+import type { WsBridge } from '../bridge/ws-host.js';
+
+class StubBridge extends EventEmitter {
+  ready = false;
+  sentCommands: { action: string; params: Record<string, unknown> }[] = [];
+
+  isReady(): boolean {
+    return this.ready;
+  }
+
+  sendCommand(action: string, params: Record<string, unknown>): Promise<unknown> {
+    this.sentCommands.push({ action, params });
+    return Promise.resolve(null);
+  }
+
+  onEvent(
+    handler: (msg: { source: string; eventType: string; data: unknown; timestamp: number }) => void,
+  ) {
+    this.on('event', handler);
+    return () => this.off('event', handler);
+  }
+}
+
+function makeBridge(): { bridge: WsBridge; stub: StubBridge } {
+  const stub = new StubBridge();
+  return { bridge: stub as unknown as WsBridge, stub };
+}
+
+test('register validates url and intervalMin', async () => {
+  const { bridge, stub } = makeBridge();
+  const r = new MonitorRegistry(bridge);
+  await assert.rejects(r.register({ slug: '', url: 'http://x', intervalMin: 1 }), /slug required/);
+  await assert.rejects(
+    r.register({ slug: 'x', url: 'ftp://x', intervalMin: 1 }),
+    /url must be http/,
+  );
+  await assert.rejects(r.register({ slug: 'x', url: 'http://x', intervalMin: 0 }), /intervalMin/);
+  assert.equal(stub.sentCommands.length, 0);
+});
+
+test('register defaults realtime per slug', async () => {
+  const { bridge } = makeBridge();
+  const r = new MonitorRegistry(bridge);
+  await r.register({ slug: 'whatsapp', url: 'http://w', intervalMin: 1 });
+  await r.register({ slug: 'gmail', url: 'http://g', intervalMin: 5 });
+  const list = r.list();
+  assert.equal(list.find((m) => m.slug === 'whatsapp')?.realtime, true);
+  assert.equal(list.find((m) => m.slug === 'gmail')?.realtime, false);
+  assert.ok(DEFAULT_REALTIME_SLUGS.has('whatsapp'));
+});
+
+test('pushes set_monitors when bridge becomes ready', async () => {
+  const { bridge, stub } = makeBridge();
+  const r = new MonitorRegistry(bridge);
+  await r.register({ slug: 'gmail', url: 'http://g', intervalMin: 5 });
+  // Bridge wasn't ready, so pushAll() silently skipped.
+  assert.equal(stub.sentCommands.length, 0);
+  // Flip to ready and emit 'ready' — pushAll should fire.
+  stub.ready = true;
+  stub.emit('ready', { extensionId: 'x' });
+  await new Promise((r) => setTimeout(r, 0));
+  assert.equal(stub.sentCommands.length, 1);
+  assert.equal(stub.sentCommands[0].action, 'set_monitors');
+});
+
+test('records twin_log events into the per-slug ring buffer', () => {
+  const { bridge, stub } = makeBridge();
+  const r = new MonitorRegistry(bridge);
+  for (let i = 0; i < 5; i += 1) {
+    stub.emit('event', {
+      source: 'gmail',
+      eventType: 'twin_log',
+      data: { i },
+      timestamp: 1000 + i,
+    });
+  }
+  const out = r.results_for('gmail', 10);
+  assert.equal(out.length, 5);
+  assert.deepEqual(out[0].data, { i: 0 });
+  assert.deepEqual(out[4].data, { i: 4 });
+});
+
+test('ring buffer caps at maxResultsPerSlug', () => {
+  const { bridge, stub } = makeBridge();
+  const r = new MonitorRegistry(bridge);
+  for (let i = 0; i < 150; i += 1) {
+    stub.emit('event', {
+      source: 'slack',
+      eventType: 'twin_log',
+      data: { i },
+      timestamp: i,
+    });
+  }
+  const out = r.results_for('slack', 200);
+  assert.equal(out.length, 100); // capped
+  assert.deepEqual(out[0].data, { i: 50 }); // oldest 50 dropped
+});
+
+test('results_for() with no slug merges + sorts by ts desc', () => {
+  const { bridge, stub } = makeBridge();
+  const r = new MonitorRegistry(bridge);
+  stub.emit('event', { source: 'a', eventType: 'twin_log', data: 1, timestamp: 100 });
+  stub.emit('event', { source: 'b', eventType: 'twin_log', data: 2, timestamp: 200 });
+  stub.emit('event', { source: 'a', eventType: 'twin_log', data: 3, timestamp: 50 });
+  const out = r.results_for(undefined, 5);
+  assert.deepEqual(
+    out.map((x) => x.ts),
+    [200, 100, 50],
+  );
+});
+
+test('unregister returns false when slug is unknown', async () => {
+  const { bridge } = makeBridge();
+  const r = new MonitorRegistry(bridge);
+  assert.equal(await r.unregister('nope'), false);
+});

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "format:check": "prettier --check .",
     "typecheck": "tsc --build && npm -w @claude-twin/desktop run typecheck && npm -w @claude-twin/vscode-extension run typecheck",
     "build": "npm run --workspaces --if-present build",
-    "test": "npm run --workspaces --if-present test",
+    "test": "npm -w @claude-twin/mcp-server run build && npm run --workspaces --if-present test",
     "clean": "tsc --build --clean && rimraf '*/dist'"
   },
   "devDependencies": {


### PR DESCRIPTION
Closes #73, #74

18 passing tests on the bridge + monitor registry. CI runs them. `docs/release.md` documents the secrets a human needs to set in repo settings before tagging.