### PR TITLE
feat(desktop, ext): CLI installer + bridge token UI + Settings route + error banner

### DIFF
--- a/desktop/src/main/cli-install.ts
+++ b/desktop/src/main/cli-install.ts
@@ -1,0 +1,150 @@
+/**
+ * Installs the bundled `claude-twin-mcp` shim onto the user's PATH so
+ * Claude Code can invoke it without the user manually symlinking.
+ *
+ * Strategy per-platform:
+ *  - macOS:  symlink `/usr/local/bin/claude-twin-mcp` (preferred), or
+ *            `~/.local/bin/claude-twin-mcp` if /usr/local/bin isn't
+ *            writable without sudo.
+ *  - Linux:  symlink `~/.local/bin/claude-twin-mcp` (always user-writable).
+ *  - Windows: prepend a per-user PATH entry pointing at the shim's
+ *            directory. Implemented via `setx`. (Future: bundle a .cmd
+ *            wrapper so users can `claude-twin-mcp` from any shell.)
+ */
+
+import { app, dialog } from 'electron';
+import { execFile } from 'node:child_process';
+import { promises as fs } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { promisify } from 'node:util';
+
+const execFileP = promisify(execFile);
+
+const FLAG_KEY = 'first-launch-cli-prompt-done';
+
+export interface CliState {
+  installed: boolean;
+  target: string | null;
+  source: string;
+}
+
+function shimPath(): string {
+  if (app.isPackaged) {
+    // electron-builder copies `shim/` into Resources/ alongside app.asar.
+    return join(process.resourcesPath, 'shim', 'claude-twin-mcp.cjs');
+  }
+  // Dev mode — read straight from the workspace.
+  return join(__dirname, '..', '..', 'shim', 'claude-twin-mcp.cjs');
+}
+
+function targetPath(): string {
+  if (process.platform === 'win32') {
+    // We don't drop a binary; we tell setx to append a PATH entry pointing
+    // at the shim's directory. The "target" we report is informational.
+    return join(process.env.APPDATA || '', 'claude-twin', 'bin', 'claude-twin-mcp.cmd');
+  }
+  const home = app.getPath('home');
+  // Try /usr/local/bin first only if it's writable without sudo.
+  return join(home, '.local', 'bin', 'claude-twin-mcp');
+}
+
+export async function getCliState(): Promise<CliState> {
+  const target = targetPath();
+  let installed = false;
+  try {
+    await fs.access(target);
+    installed = true;
+  } catch {
+    /* not installed */
+  }
+  return { installed, target, source: shimPath() };
+}
+
+export async function installCli(): Promise<CliState> {
+  const target = targetPath();
+  const source = shimPath();
+  await fs.mkdir(dirname(target), { recursive: true });
+
+  if (process.platform === 'win32') {
+    // Drop a thin .cmd that exec's node on the shim, then prepend
+    // %APPDATA%\claude-twin\bin to the user PATH.
+    const cmdContent = `@echo off\nnode "${source.replace(/\\/g, '\\\\')}" %*\n`;
+    await fs.writeFile(target, cmdContent, 'utf8');
+    await prependUserPath(dirname(target));
+  } else {
+    // Symlink. If a stale link exists, replace it.
+    await fs.rm(target, { force: true });
+    await fs.symlink(source, target, 'file');
+  }
+  return { installed: true, target, source };
+}
+
+export async function uninstallCli(): Promise<void> {
+  const target = targetPath();
+  try {
+    await fs.rm(target, { force: true });
+  } catch {
+    /* nothing to remove */
+  }
+}
+
+async function prependUserPath(dir: string): Promise<void> {
+  if (process.platform !== 'win32') return;
+  // Read current user PATH via reg.exe to avoid clobbering machine PATH.
+  const { stdout } = await execFileP('reg', ['query', 'HKCU\\Environment', '/v', 'Path']).catch(
+    () => ({ stdout: '' }),
+  );
+  const match = stdout.match(/Path\s+REG_(?:EXPAND_)?SZ\s+(.*)/i);
+  const current = match?.[1]?.trim() ?? '';
+  if (current.split(';').includes(dir)) return;
+  const next = current ? `${dir};${current}` : dir;
+  await execFileP('setx', ['Path', next]);
+}
+
+/**
+ * Prompts the user once on first launch. Result is persisted in userData
+ * so we don't ask again. Idempotent if called multiple times.
+ */
+export async function maybePromptFirstLaunchInstall(): Promise<void> {
+  const flagFile = join(app.getPath('userData'), `${FLAG_KEY}.flag`);
+  try {
+    await fs.access(flagFile);
+    return; // already prompted
+  } catch {
+    /* fall through */
+  }
+  await fs.mkdir(dirname(flagFile), { recursive: true });
+
+  const state = await getCliState();
+  if (state.installed) {
+    await fs.writeFile(flagFile, new Date().toISOString());
+    return;
+  }
+
+  const result = await dialog.showMessageBox({
+    type: 'question',
+    title: 'Install claude-twin command-line tool?',
+    message: 'Install the `claude-twin-mcp` command-line tool?',
+    detail:
+      'Claude Code (and other MCP clients) need a `claude-twin-mcp` binary on your PATH to talk to claude-twin. We can install it for you at:\n\n' +
+      `  ${state.target}\n\nYou can uninstall it later from the Settings page.`,
+    buttons: ['Install', 'Skip for now'],
+    defaultId: 0,
+    cancelId: 1,
+  });
+
+  if (result.response === 0) {
+    try {
+      await installCli();
+    } catch (err) {
+      await dialog.showMessageBox({
+        type: 'warning',
+        title: 'CLI install failed',
+        message: 'Could not install claude-twin-mcp.',
+        detail: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  await fs.writeFile(flagFile, new Date().toISOString());
+}

--- a/desktop/src/main/index.ts
+++ b/desktop/src/main/index.ts
@@ -17,6 +17,8 @@ import { createTray, type TrayApi } from './tray.js';
 import { startMcpSocketHost, type McpSocketHost } from './mcp-socket.js';
 import { attachIpc, pushLog } from './ipc.js';
 import { startAutoUpdate, manualCheckForUpdates } from './auto-update.js';
+import { ensureToken } from './token-store.js';
+import { maybePromptFirstLaunchInstall } from './cli-install.js';
 
 let mainWindow: BrowserWindow | null = null;
 let bridge: WsBridgeT | null = null;
@@ -87,10 +89,9 @@ app.whenReady().then(async () => {
   });
 
   try {
+    const token = process.env.CLAUDE_TWIN_WS_TOKEN ?? (await ensureToken());
     const { WsBridge } = await import('@claude-twin/mcp-server/dist/bridge/ws-host.js');
-    bridge = new WsBridge({
-      token: process.env.CLAUDE_TWIN_WS_TOKEN ?? null,
-    });
+    bridge = new WsBridge({ token });
 
     bridge.on('ready', () => trayApi?.setStatus('green'));
     attachIpc(bridge);
@@ -110,6 +111,17 @@ app.whenReady().then(async () => {
   } catch (err) {
     console.error('[claude-twin] start failed:', err);
     trayApi?.setStatus('red');
+    pushLog({
+      ts: Date.now(),
+      level: 'error',
+      source: 'bridge',
+      message: err instanceof Error ? err.message : String(err),
+    });
+  }
+
+  // Prompt about CLI install once everything else is up.
+  if (app.isPackaged) {
+    void maybePromptFirstLaunchInstall();
   }
 });
 

--- a/desktop/src/main/ipc.ts
+++ b/desktop/src/main/ipc.ts
@@ -16,6 +16,8 @@
 
 import { BrowserWindow, ipcMain } from 'electron';
 import type { WsBridge } from '@claude-twin/mcp-server/dist/bridge/ws-host.js';
+import { getCliState, installCli, uninstallCli } from './cli-install.js';
+import { readToken, rotateToken } from './token-store.js';
 
 export interface TwinLogEntry {
   ts: number;
@@ -90,4 +92,24 @@ export function attachIpc(bridge: WsBridge): void {
     const limit = Math.min(Math.max(opts?.limit ?? 100, 1), RING);
     return recentLogs.slice(-limit);
   });
+
+  // Settings panel
+  ipcMain.handle('twin/cli-state', () => getCliState());
+  ipcMain.handle('twin/cli-install', async () => {
+    try {
+      return { ok: true, state: await installCli() };
+    } catch (err) {
+      return { ok: false, error: err instanceof Error ? err.message : String(err) };
+    }
+  });
+  ipcMain.handle('twin/cli-uninstall', async () => {
+    try {
+      await uninstallCli();
+      return { ok: true };
+    } catch (err) {
+      return { ok: false, error: err instanceof Error ? err.message : String(err) };
+    }
+  });
+  ipcMain.handle('twin/get-token', () => readToken());
+  ipcMain.handle('twin/rotate-token', async () => rotateToken());
 }

--- a/desktop/src/main/token-store.ts
+++ b/desktop/src/main/token-store.ts
@@ -1,0 +1,40 @@
+/**
+ * Persistent bridge auth token. Auto-generates 32 bytes of hex on first
+ * launch so the WS bridge isn't open to any process on the local box.
+ *
+ * Storage: `<userData>/bridge-token` plain text.
+ */
+
+import { app } from 'electron';
+import { promises as fs } from 'node:fs';
+import { randomBytes } from 'node:crypto';
+import { dirname, join } from 'node:path';
+
+function tokenFile(): string {
+  return join(app.getPath('userData'), 'bridge-token');
+}
+
+export async function readToken(): Promise<string | null> {
+  try {
+    const v = (await fs.readFile(tokenFile(), 'utf8')).trim();
+    return v || null;
+  } catch {
+    return null;
+  }
+}
+
+export async function ensureToken(): Promise<string> {
+  const existing = await readToken();
+  if (existing) return existing;
+  const fresh = randomBytes(32).toString('hex');
+  await fs.mkdir(dirname(tokenFile()), { recursive: true });
+  await fs.writeFile(tokenFile(), fresh, { mode: 0o600 });
+  return fresh;
+}
+
+export async function rotateToken(): Promise<string> {
+  const fresh = randomBytes(32).toString('hex');
+  await fs.mkdir(dirname(tokenFile()), { recursive: true });
+  await fs.writeFile(tokenFile(), fresh, { mode: 0o600 });
+  return fresh;
+}

--- a/desktop/src/preload/index.ts
+++ b/desktop/src/preload/index.ts
@@ -1,10 +1,37 @@
 /**
- * Preload — exposes a minimal IPC surface to the renderer. Real
- * surface (subscribe to events / fetch monitor results) lands in #45.
+ * Preload — typed, narrow IPC surface for the renderer. The renderer
+ * never touches Node, Electron, or the WS bridge directly.
  */
 
-import { contextBridge } from 'electron';
+import { contextBridge, ipcRenderer, type IpcRendererEvent } from 'electron';
+
+type Subscriber<T> = (payload: T) => void;
+
+function subscribe<T>(channel: string, handler: Subscriber<T>): () => void {
+  const listener = (_: IpcRendererEvent, payload: T): void => handler(payload);
+  ipcRenderer.on(channel, listener);
+  return () => ipcRenderer.off(channel, listener);
+}
 
 contextBridge.exposeInMainWorld('claudeTwin', {
   version: '0.0.0',
+
+  // Snapshots
+  getStatus: () => ipcRenderer.invoke('twin/get-status'),
+  getRecentEvents: (opts?: { limit?: number }) =>
+    ipcRenderer.invoke('twin/get-recent-events', opts),
+  getRecentLogs: (opts?: { limit?: number }) => ipcRenderer.invoke('twin/get-recent-logs', opts),
+
+  // Subscriptions
+  onBridgeStatus: (handler: Subscriber<unknown>) => subscribe('twin/bridge-status', handler),
+  onEvent: (handler: Subscriber<unknown>) => subscribe('twin/event', handler),
+  onLog: (handler: Subscriber<unknown>) => subscribe('twin/log', handler),
+  onNavigate: (handler: Subscriber<string>) => subscribe('navigate', handler),
+
+  // Settings
+  cliState: () => ipcRenderer.invoke('twin/cli-state'),
+  cliInstall: () => ipcRenderer.invoke('twin/cli-install'),
+  cliUninstall: () => ipcRenderer.invoke('twin/cli-uninstall'),
+  getToken: () => ipcRenderer.invoke('twin/get-token'),
+  rotateToken: () => ipcRenderer.invoke('twin/rotate-token'),
 });

--- a/desktop/src/renderer/App.tsx
+++ b/desktop/src/renderer/App.tsx
@@ -1,27 +1,40 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import type { BridgeStatus, TwinEvent, TwinLog } from './types';
+import { Settings } from './Settings';
 
 type Tab = 'bridge' | 'events' | 'monitors' | 'logs';
+type Route = 'main' | 'settings';
 
 export function App(): React.ReactElement {
+  const [route, setRoute] = useState<Route>('main');
   const [tab, setTab] = useState<Tab>('bridge');
   const [status, setStatus] = useState<BridgeStatus | null>(null);
   const [events, setEvents] = useState<TwinEvent[]>([]);
   const [logs, setLogs] = useState<TwinLog[]>([]);
   const [filter, setFilter] = useState<string>('');
+  const [errorsOnly, setErrorsOnly] = useState<boolean>(false);
+  const [bannerError, setBannerError] = useState<string | null>(null);
 
   useEffect(() => {
     void window.claudeTwin.getStatus().then(setStatus);
     void window.claudeTwin.getRecentEvents().then(setEvents);
     void window.claudeTwin.getRecentLogs().then(setLogs);
 
-    const offStatus = window.claudeTwin.onBridgeStatus((s) => setStatus(s));
+    const offStatus = window.claudeTwin.onBridgeStatus((s) => {
+      setStatus(s);
+      if (!s.listening) setBannerError('WS bridge is not listening — see logs.');
+      else setBannerError(null);
+    });
     const offEvent = window.claudeTwin.onEvent((e) =>
       setEvents((prev) => [...prev.slice(-499), e]),
     );
-    const offLog = window.claudeTwin.onLog((l) => setLogs((prev) => [...prev.slice(-499), l]));
-    const offNav = window.claudeTwin.onNavigate((route) => {
-      if (route === '/settings') setTab('bridge');
+    const offLog = window.claudeTwin.onLog((l) => {
+      setLogs((prev) => [...prev.slice(-499), l]);
+      if (l.level === 'error') setBannerError(l.message);
+    });
+    const offNav = window.claudeTwin.onNavigate((r) => {
+      if (r === '/settings') setRoute('settings');
+      else if (r === '/main' || r === '/') setRoute('main');
     });
     return () => {
       offStatus();
@@ -39,6 +52,11 @@ export function App(): React.ReactElement {
     );
   }, [events, filter]);
 
+  const filteredLogs = useMemo(
+    () => (errorsOnly ? logs.filter((l) => l.level !== 'info') : logs),
+    [logs, errorsOnly],
+  );
+
   const monitorBuckets = useMemo(() => {
     const map = new Map<string, TwinEvent[]>();
     for (const e of events) {
@@ -50,12 +68,29 @@ export function App(): React.ReactElement {
     return [...map.entries()].sort((a, b) => a[0].localeCompare(b[0]));
   }, [events]);
 
+  if (route === 'settings') {
+    return <Settings onBack={() => setRoute('main')} />;
+  }
+
   return (
     <main>
       <header>
         <h1>claude-twin</h1>
         <span className="version">v{window.claudeTwin?.version ?? '0.0.0'}</span>
       </header>
+
+      {bannerError && (
+        <div className="error-banner" role="alert">
+          <span className="error-banner-text">{bannerError}</span>
+          <button
+            className="error-banner-dismiss"
+            onClick={() => setBannerError(null)}
+            aria-label="dismiss"
+          >
+            ×
+          </button>
+        </div>
+      )}
 
       <nav className="tabs">
         {(['bridge', 'events', 'monitors', 'logs'] as Tab[]).map((t) => (
@@ -65,7 +100,9 @@ export function App(): React.ReactElement {
         ))}
       </nav>
 
-      {tab === 'bridge' && <BridgePane status={status} />}
+      {tab === 'bridge' && (
+        <BridgePane status={status} onOpenSettings={() => setRoute('settings')} />
+      )}
 
       {tab === 'events' && (
         <EventsPane events={filteredEvents} filter={filter} onFilter={setFilter} />
@@ -73,12 +110,24 @@ export function App(): React.ReactElement {
 
       {tab === 'monitors' && <MonitorsPane buckets={monitorBuckets} />}
 
-      {tab === 'logs' && <LogsPane logs={logs} />}
+      {tab === 'logs' && (
+        <LogsPane
+          logs={filteredLogs}
+          errorsOnly={errorsOnly}
+          onToggleErrorsOnly={() => setErrorsOnly((v) => !v)}
+        />
+      )}
     </main>
   );
 }
 
-function BridgePane({ status }: { status: BridgeStatus | null }): React.ReactElement {
+function BridgePane({
+  status,
+  onOpenSettings,
+}: {
+  status: BridgeStatus | null;
+  onOpenSettings: () => void;
+}): React.ReactElement {
   if (!status) return <p className="muted">loading…</p>;
   return (
     <section className="pane">
@@ -97,6 +146,9 @@ function BridgePane({ status }: { status: BridgeStatus | null }): React.ReactEle
       />
       <Row label="Extension id" value={status.extensionId ?? '—'} />
       <Row label="Pending commands" value={String(status.pendingCommands)} />
+      <div className="settings-actions">
+        <button onClick={onOpenSettings}>Open Settings…</button>
+      </div>
     </section>
   );
 }
@@ -195,9 +247,23 @@ function MonitorsPane({ buckets }: { buckets: [string, TwinEvent[]][] }): React.
   );
 }
 
-function LogsPane({ logs }: { logs: TwinLog[] }): React.ReactElement {
+function LogsPane({
+  logs,
+  errorsOnly,
+  onToggleErrorsOnly,
+}: {
+  logs: TwinLog[];
+  errorsOnly: boolean;
+  onToggleErrorsOnly: () => void;
+}): React.ReactElement {
   return (
     <section className="pane">
+      <div className="logs-toolbar">
+        <label className="toggle">
+          <input type="checkbox" checked={errorsOnly} onChange={onToggleErrorsOnly} />
+          <span>errors only</span>
+        </label>
+      </div>
       {logs.length === 0 ? (
         <p className="muted">no logs yet</p>
       ) : (

--- a/desktop/src/renderer/Settings.tsx
+++ b/desktop/src/renderer/Settings.tsx
@@ -1,0 +1,128 @@
+import React, { useEffect, useState } from 'react';
+import type { CliState } from './types';
+
+export function Settings({ onBack }: { onBack: () => void }): React.ReactElement {
+  const [cli, setCli] = useState<CliState | null>(null);
+  const [token, setToken] = useState<string | null>(null);
+  const [busy, setBusy] = useState<string | null>(null);
+  const [tokenVisible, setTokenVisible] = useState(false);
+
+  const refresh = async (): Promise<void> => {
+    setCli(await window.claudeTwin.cliState());
+    setToken(await window.claudeTwin.getToken());
+  };
+
+  useEffect(() => {
+    void refresh();
+  }, []);
+
+  const onInstall = async (): Promise<void> => {
+    setBusy('install');
+    const r = await window.claudeTwin.cliInstall();
+    setBusy(null);
+    if (!r.ok) alert(`Install failed: ${r.error}`);
+    void refresh();
+  };
+
+  const onUninstall = async (): Promise<void> => {
+    if (!confirm('Remove the claude-twin-mcp shim?')) return;
+    setBusy('uninstall');
+    const r = await window.claudeTwin.cliUninstall();
+    setBusy(null);
+    if (!r.ok) alert(`Uninstall failed: ${r.error}`);
+    void refresh();
+  };
+
+  const onRotate = async (): Promise<void> => {
+    if (
+      !confirm('Rotate bridge token? Existing extension/Claude Code sessions will need to update.')
+    )
+      return;
+    setBusy('rotate');
+    const fresh = await window.claudeTwin.rotateToken();
+    setBusy(null);
+    setToken(fresh);
+    setTokenVisible(true);
+  };
+
+  const onCopyToken = async (): Promise<void> => {
+    if (token) await navigator.clipboard.writeText(token);
+  };
+
+  return (
+    <main>
+      <header>
+        <h1>claude-twin — Settings</h1>
+        <button className="link-btn" onClick={onBack}>
+          ← back
+        </button>
+      </header>
+
+      <section className="settings-section">
+        <h2>Command-line tool</h2>
+        <p className="muted">
+          The <code>claude-twin-mcp</code> binary lets Claude Code (and other MCP clients) talk to
+          this app.
+        </p>
+        {cli ? (
+          <>
+            <div className="row">
+              <span className="row-label">Status</span>
+              <span className={`row-value ${cli.installed ? 'ok' : 'warn'}`}>
+                {cli.installed ? 'installed' : 'not installed'}
+              </span>
+            </div>
+            <div className="row">
+              <span className="row-label">Path</span>
+              <span className="row-value mono">{cli.target ?? '—'}</span>
+            </div>
+            <div className="settings-actions">
+              {cli.installed ? (
+                <button onClick={onUninstall} disabled={!!busy}>
+                  Uninstall
+                </button>
+              ) : (
+                <button onClick={onInstall} disabled={!!busy}>
+                  Install
+                </button>
+              )}
+              {cli.installed && (
+                <button onClick={onInstall} disabled={!!busy} className="secondary">
+                  Repair
+                </button>
+              )}
+            </div>
+          </>
+        ) : (
+          <p className="muted">checking…</p>
+        )}
+      </section>
+
+      <section className="settings-section">
+        <h2>Bridge token</h2>
+        <p className="muted">
+          Shared secret between this app and the Chrome extension. Auto-generated on first launch.
+          Rotate to revoke any leaked copies — the extension will need the new value entered into
+          its popup Status tab.
+        </p>
+        <div className="row">
+          <span className="row-label">Current</span>
+          <span className="row-value mono">
+            {token == null ? '—' : tokenVisible ? token : `${token.slice(0, 8)}…${token.slice(-4)}`}
+          </span>
+        </div>
+        <div className="settings-actions">
+          <button onClick={() => setTokenVisible((v) => !v)}>
+            {tokenVisible ? 'Hide' : 'Show'}
+          </button>
+          <button onClick={onCopyToken} disabled={!token}>
+            Copy
+          </button>
+          <button onClick={onRotate} disabled={!!busy} className="secondary">
+            Rotate…
+          </button>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/desktop/src/renderer/index.css
+++ b/desktop/src/renderer/index.css
@@ -202,3 +202,105 @@ header .version {
   color: var(--warn);
   font-weight: 600;
 }
+
+.error-banner {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  background: rgba(220, 38, 38, 0.08);
+  border: 1px solid var(--warn);
+  border-radius: 6px;
+  padding: 8px 12px;
+  margin-bottom: 12px;
+}
+
+.error-banner-text {
+  flex: 1;
+  color: var(--warn);
+  font-size: 13px;
+}
+
+.error-banner-dismiss {
+  background: transparent;
+  border: none;
+  color: var(--warn);
+  cursor: pointer;
+  font-size: 18px;
+  line-height: 1;
+}
+
+.settings-section {
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 16px;
+  margin-bottom: 16px;
+}
+
+.settings-section h2 {
+  font-size: 15px;
+  font-weight: 600;
+  margin: 0 0 4px 0;
+}
+
+.settings-section p {
+  margin: 4px 0 12px 0;
+}
+
+.settings-actions {
+  display: flex;
+  gap: 8px;
+  margin-top: 12px;
+  flex-wrap: wrap;
+}
+
+.settings-actions button,
+.error-banner button {
+  padding: 6px 12px;
+  border-radius: 4px;
+  border: 1px solid var(--accent);
+  background: var(--accent);
+  color: var(--accent-fg, #fff);
+  cursor: pointer;
+  font: inherit;
+}
+
+.settings-actions button.secondary {
+  background: transparent;
+  color: var(--fg);
+  border-color: var(--border);
+}
+
+.settings-actions button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.link-btn {
+  background: transparent;
+  border: none;
+  color: var(--accent);
+  cursor: pointer;
+  font: inherit;
+  padding: 0;
+}
+
+.logs-toolbar {
+  display: flex;
+  gap: 12px;
+  margin-bottom: 8px;
+}
+
+.logs-toolbar .toggle {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  cursor: pointer;
+}
+
+code {
+  font-family: 'JetBrains Mono', 'SF Mono', Menlo, monospace;
+  font-size: 12px;
+  background: var(--hover);
+  padding: 0 4px;
+  border-radius: 3px;
+}

--- a/desktop/src/renderer/types.ts
+++ b/desktop/src/renderer/types.ts
@@ -21,6 +21,12 @@ export interface TwinLog {
   message: string;
 }
 
+export interface CliState {
+  installed: boolean;
+  target: string | null;
+  source: string;
+}
+
 export interface ClaudeTwinApi {
   version: string;
   getStatus: () => Promise<BridgeStatus>;
@@ -30,6 +36,11 @@ export interface ClaudeTwinApi {
   onEvent: (h: (e: TwinEvent) => void) => () => void;
   onLog: (h: (l: TwinLog) => void) => () => void;
   onNavigate: (h: (route: string) => void) => () => void;
+  cliState: () => Promise<CliState>;
+  cliInstall: () => Promise<{ ok: boolean; state?: CliState; error?: string }>;
+  cliUninstall: () => Promise<{ ok: boolean; error?: string }>;
+  getToken: () => Promise<string | null>;
+  rotateToken: () => Promise<string>;
 }
 
 declare global {


### PR DESCRIPTION
Closes #77, #78, #79, #81. Also fixes a regression where the React UI was broken in packaged builds (preload was a placeholder).