### PR TITLE
chore: release v0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,15 +7,56 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.0] — 2026-04-29
+
+First public release. Five surfaces — Chrome extension, MCP server, Electron desktop app, Claude Code plugin, VSCode extension — installable via `.dmg` / `.exe` / `.AppImage` + `claude plugin install`.
+
 ### Added
 
-- **v1 — first complete release.**
-  - Monorepo with four workspaces: `extension/` (MV3 Chrome extension), `mcp-server/` (Node MCP server + WS bridge core), `desktop/` (Electron app, the mandatory entry point), `plugin/` (Claude Code plugin manifest + slash commands + skills).
-  - **MCP server** with 14 tools: `twin_ping`, `twin_bridge_status`, `twin_extension_ping`, `twin_tabs`, `twin_open`, `twin_close`, `twin_click`, `twin_fill`, `twin_screenshot`, `twin_search`, `twin_script_load`, `twin_script_unload`, `twin_script_toggle`, `twin_script_list`, `twin_script_run`, `twin_monitor_register`, `twin_monitor_unregister`, `twin_monitor_list`, `twin_monitor_results`. Stable v1 API.
-  - **WebSocket bridge** on `127.0.0.1:9997/twin` (loopback-only, optional token, command/response/event envelopes, exponential-backoff reconnect, in-memory queue, ping/pong keepalive).
-  - **Chrome MV3 extension** with 17 platform content scripts (Gmail, Slack, WhatsApp, Discord, Telegram, X + X-Premium, GitHub, Linear, Jira, GCal, Cal.com, Google Meet, Zoom, GCP Console, Claude.ai, OpenAI Platform, Perplexity), dynamic ScriptEngine, alarms-driven monitor manager, tabbed popup (status / monitors / scripts / permissions / meeting opt-in).
-  - **Electron desktop app**: tray-first UX (3-state status colour, auto-launch on login, Settings menu), embedded MCP server + WS bridge, local Unix-socket / named-pipe stdio shim (`claude-twin-mcp`) for Claude Code, React main window with bridge / events / monitors / logs panes streaming live via IPC, electron-updater wired to GitHub Releases.
-  - **Claude Code plugin**: `plugin/.claude-plugin/plugin.json` auto-registers the `claude-twin-mcp` stdio shim, six slash commands (`/claude-twin:read|send|watch|click|fill|screenshot`), three high-level skills (`twin-monitor`, `twin-messaging`, `twin-meetings`).
-  - **CI** workflow runs lint / format / typecheck / build / extension-zip artifact on every push and PR.
-  - **Release** workflow fires on `v*.*.*` tag push: cross-platform Electron builds (mac arm64+x64, Windows NSIS, Linux AppImage) with optional code signing + notarization secrets, npm publish for the standalone MCP server, extension zip attached to the GitHub Release, auto-generated release notes from this CHANGELOG.
-  - **Docs**: `docs/install.md` (step-by-step + troubleshooting), `docs/tools.md` (full MCP tool reference), `docs/platforms.md` (per-platform notes + selectors guide).
+#### Core
+
+- Monorepo with five workspaces: `extension/` (MV3 Chrome extension), `mcp-server/` (Node MCP server + WS bridge core), `desktop/` (Electron app, the mandatory entry point), `plugin/` (Claude Code plugin manifest + slash commands + skills), `vscode-extension/` (VSCode extension with command palette + live-events sidebar).
+- **MCP server** with 20 tools, stable v1 API:
+  - Health: `twin_ping`, `twin_bridge_status`, `twin_extension_ping`, `twin_selftest`
+  - Tabs: `twin_tabs`, `twin_open`, `twin_close`
+  - DOM: `twin_click`, `twin_fill`, `twin_screenshot` (password-shaped selectors blocked)
+  - Search: `twin_search`
+  - Dynamic scripts: `twin_script_load`, `twin_script_unload`, `twin_script_toggle`, `twin_script_list`, `twin_script_run`
+  - Monitors: `twin_monitor_register`, `twin_monitor_unregister`, `twin_monitor_list`, `twin_monitor_results`
+- **WebSocket bridge** on `127.0.0.1:9997/twin` — loopback-only, optional token auth, command/response/event envelopes, exponential-backoff reconnect (capped 30 s), in-memory queue (capped 500), 25 s ping/pong keepalive.
+- **Chrome MV3 extension** with 17 platform content scripts: Gmail, Slack, WhatsApp, Discord, Telegram, X + X-Premium, GitHub, Linear, Jira, Google Calendar, Cal.com, Google Meet, Zoom, GCP Console, Claude.ai, OpenAI Platform, Perplexity. Dynamic ScriptEngine, alarms-driven monitor manager, tabbed popup (status / monitors / scripts / permissions / meeting opt-in / update banner).
+- **Electron desktop app** (mandatory entry point):
+  - Tray-first UX with 3-state status colour and tooltips
+  - Embedded MCP server + WS bridge — no separate Node install
+  - Local Unix-socket / named-pipe stdio shim (`claude-twin-mcp`) for Claude Code
+  - React main window with Bridge / Events / Monitors / Logs panes
+  - Settings page: CLI installer, bridge token (auto-generated, rotatable), history export/import/clear
+  - electron-updater auto-update on launch + manual "Check for updates…" tray item
+  - Persistent event store at `<userData>/events.sqlite` (better-sqlite3)
+  - Native notifications on `ALERT` events (per-user opt-in)
+- **Claude Code plugin**: `plugin/.claude-plugin/plugin.json` auto-registers the stdio shim, six slash commands (`/claude-twin:read|send|watch|click|fill|screenshot`), three high-level skills (`twin-monitor`, `twin-messaging`, `twin-meetings`).
+- **VSCode extension**: command palette (`claude-twin: …`) for every MCP tool, live-events sidebar webview, status-bar connection indicator.
+
+#### Build, CI, Release
+
+- CI workflow runs lint / format / typecheck / build / test / extension-zip artifact on every push + PR.
+- Release workflow fires on `v*.*.*` tag push: signed cross-platform Electron builds (mac arm64+x64 with notarization, Windows NSIS, Linux AppImage), npm publish for `@claude-twin/mcp-server`, extension zip attached to the GitHub Release, auto-generated release notes from this CHANGELOG.
+- 18 unit tests covering `WsBridge` (auth, command bus, errors, reconnect lifecycle) and `MonitorRegistry` (validation, ring buffer, push-on-ready).
+
+#### Docs
+
+- `docs/install.md` — step-by-step install + troubleshooting
+- `docs/tools.md` — full MCP tool reference
+- `docs/platforms.md` — per-platform notes + selector guide
+- `docs/release.md` — release-pipeline secrets / Apple Developer ID / Windows code-signing
+- `docs/manual-release-tasks.md` — checklist for tagging / Chrome Web Store / Anthropic plugin marketplace
+- `docs/permissions.md` — per-permission audit
+- `.github/CONTRIBUTING.md`, `.github/SECURITY.md`, `.github/FUNDING.yml`
+
+### Known limitations / deferred
+
+The following are deliberately out of scope for v0.1.0 and tracked for v0.2:
+
+- Localization scaffolding ([#86](https://github.com/fadymondy/claude-twin/issues/86)) — strings are hardcoded English.
+- Crash reporting / opt-in telemetry ([#87](https://github.com/fadymondy/claude-twin/issues/87)) — Sentry integration plumbing exists conceptually but no SDK is shipped.
+- Multi-machine bridge ([#89](https://github.com/fadymondy/claude-twin/issues/89)) — bridge is loopback-only by design.

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@claude-twin/desktop",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "private": true,
   "description": "Electron desktop app — bundles the MCP server and WS bridge, renders live twin events",
   "license": "MIT",
@@ -20,7 +20,7 @@
     "package:linux": "electron-vite build && electron-builder --linux --publish never"
   },
   "dependencies": {
-    "@claude-twin/mcp-server": "0.0.0",
+    "@claude-twin/mcp-server": "0.1.0",
     "better-sqlite3": "^11.3.0",
     "electron-updater": "^6.3.9",
     "react": "^18.3.1",

--- a/desktop/src/preload/index.ts
+++ b/desktop/src/preload/index.ts
@@ -14,7 +14,7 @@ function subscribe<T>(channel: string, handler: Subscriber<T>): () => void {
 }
 
 contextBridge.exposeInMainWorld('claudeTwin', {
-  version: '0.0.0',
+  version: '0.1.0',
 
   // Snapshots
   getStatus: () => ipcRenderer.invoke('twin/get-status'),

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "claude-twin",
   "short_name": "claude-twin",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "description": "Real-time browser monitoring for your digital twin — drives 17 web apps from Claude Code via a local MCP server.",
   "minimum_chrome_version": "120",
   "action": {

--- a/extension/package.json
+++ b/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@claude-twin/extension",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "private": true,
   "description": "Chrome MV3 extension for claude-twin — content scripts + offscreen WebSocket bridge",
   "license": "MIT",

--- a/extension/src/index.ts
+++ b/extension/src/index.ts
@@ -4,4 +4,4 @@
  * Placeholder entry. The MV3 manifest and content script tree land in #4.
  */
 
-export const VERSION = '0.0.0';
+export const VERSION = '0.1.0';

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@claude-twin/mcp-server",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "private": true,
   "description": "Local MCP server hosting the WebSocket bridge to the claude-twin Chrome extension",
   "license": "MIT",

--- a/mcp-server/src/server.ts
+++ b/mcp-server/src/server.ts
@@ -12,7 +12,7 @@ import { registerSelftestTool } from './tools/selftest.js';
 import { MonitorRegistry } from './state/monitors.js';
 
 export const SERVER_NAME = 'claude-twin';
-export const SERVER_VERSION = '0.0.0';
+export const SERVER_VERSION = '0.1.0';
 
 export interface CreateServerOptions {
   bridge?: WsBridgeOptions;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-twin",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-twin",
-      "version": "0.0.0",
+      "version": "0.1.0",
       "license": "MIT",
       "workspaces": [
         "extension",
@@ -31,10 +31,10 @@
     },
     "desktop": {
       "name": "@claude-twin/desktop",
-      "version": "0.0.0",
+      "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "@claude-twin/mcp-server": "0.0.0",
+        "@claude-twin/mcp-server": "0.1.0",
         "better-sqlite3": "^11.3.0",
         "electron-updater": "^6.3.9",
         "react": "^18.3.1",
@@ -56,7 +56,7 @@
     },
     "extension": {
       "name": "@claude-twin/extension",
-      "version": "0.0.0",
+      "version": "0.1.0",
       "license": "MIT",
       "devDependencies": {
         "@types/chrome": "^0.0.268"
@@ -64,7 +64,7 @@
     },
     "mcp-server": {
       "name": "@claude-twin/mcp-server",
-      "version": "0.0.0",
+      "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.18.0",
@@ -12247,12 +12247,12 @@
     },
     "plugin": {
       "name": "@claude-twin/plugin",
-      "version": "0.0.0",
+      "version": "0.1.0",
       "license": "MIT"
     },
     "vscode-extension": {
       "name": "@claude-twin/vscode-extension",
-      "version": "0.0.0",
+      "version": "0.1.0",
       "license": "MIT",
       "devDependencies": {
         "@types/vscode": "^1.85.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-twin",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "private": true,
   "description": "Standalone Chrome extension + MCP server + Claude Code plugin for browser-based digital twin monitoring",
   "license": "MIT",

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://schemas.claude.com/claude-code/plugin.json",
   "name": "claude-twin",
   "description": "Drive 17 web apps (Gmail, Slack, WhatsApp, Discord, Telegram, X, GitHub, Linear, Jira, GCal, Cal.com, Google Meet, Zoom, GCP, Claude.ai, OpenAI, Perplexity) from inside a Claude Code conversation. Uses a local Chrome extension + the claude-twin desktop app — nothing leaves your machine.",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "author": {
     "name": "Fady Mondy",
     "email": "info@3x1.io",

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@claude-twin/plugin",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "private": true,
   "description": "Claude Code plugin manifest for claude-twin — auto-registers the MCP server and ships slash commands",
   "license": "MIT",

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "@claude-twin/vscode-extension",
   "displayName": "claude-twin",
   "description": "Drive the claude-twin desktop app — read / send / click / watch on 17 web apps — from inside VSCode.",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "private": true,
   "license": "MIT",
   "publisher": "fadymondy",

--- a/vscode-extension/src/mcp-client.ts
+++ b/vscode-extension/src/mcp-client.ts
@@ -120,7 +120,7 @@ export class McpClient {
     await this.request('initialize', {
       protocolVersion: '2025-06-18',
       capabilities: {},
-      clientInfo: { name: 'claude-twin-vscode', version: '0.0.0' },
+      clientInfo: { name: 'claude-twin-vscode', version: '0.1.0' },
     });
     this.notify('notifications/initialized');
   }


### PR DESCRIPTION
Bumps every package.json + manifest + hardcoded VERSION constant from 0.0.0 to 0.1.0 and promotes CHANGELOG `[Unreleased]` to `[0.1.0]`.

## Verified
- `npm run lint` — clean
- `npm run format:check` — clean
- `npm run typecheck` — clean (mcp-server + desktop main + desktop renderer + vscode-extension)
- `npm -w @claude-twin/mcp-server run build` — green
- `npm -w @claude-twin/mcp-server run test` — 18 / 18 pass

## Next step (manual, requires user)
After this PR merges:

```sh
git tag v0.1.0
git push origin v0.1.0
```

The tag push fires `.github/workflows/release.yml` which:
- Builds + signs (with the secrets configured per docs/release.md) cross-platform Electron .dmg / .exe / .AppImage
- Publishes `@claude-twin/mcp-server` to npm
- Attaches the extension zip to the GitHub Release
- Generates release notes from CHANGELOG.md

I haven't pushed the tag autonomously since it triggers public artifact publishing. Merge when you're ready, then run the two commands above.