### PR TITLE
fix(ci, release): drop --workspaces flag from npm ci (unblocks release pipeline)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
           cache: npm
 
       - name: Install dependencies
-        run: npm ci --workspaces --include-workspace-root
+        run: npm ci
 
       - name: Lint
         run: npm run lint
@@ -53,7 +53,7 @@ jobs:
           cache: npm
 
       - name: Install dependencies
-        run: npm ci --workspaces --include-workspace-root
+        run: npm ci
 
       - name: Build mcp-server
         run: npm -w @claude-twin/mcp-server run build
@@ -74,7 +74,7 @@ jobs:
           cache: npm
 
       - name: Install dependencies
-        run: npm ci --workspaces --include-workspace-root
+        run: npm ci
 
       - name: Build mcp-server
         run: npm -w @claude-twin/mcp-server run build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,8 +25,13 @@ jobs:
           node-version-file: .nvmrc
           cache: npm
 
+      # Don't pass --workspaces flag — npm 10/11 already installs workspaces
+      # by default, and `--workspaces --include-workspace-root` skips
+      # transitive postinstall lifecycle scripts (notably for app-builder-bin
+      # which prebuilds platform-specific electron-builder helpers, leading
+      # to "spawn .../app-builder ENOENT" at package time).
       - name: Install dependencies
-        run: npm ci --workspaces --include-workspace-root
+        run: npm ci
 
       - name: Build mcp-server
         run: npm -w @claude-twin/mcp-server run build
@@ -85,7 +90,7 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
       - name: Install + build
         run: |
-          npm ci --workspaces --include-workspace-root
+          npm ci
           npm -w @claude-twin/mcp-server run build
       - name: Publish to npm (skip if NODE_AUTH_TOKEN missing)
         env:


### PR DESCRIPTION
Failed v0.1.0 build on all three OSes was caused by `--workspaces --include-workspace-root` skipping transitive postinstall scripts → `app-builder-bin` binaries never landed → `electron-builder` got ENOENT.

Test plan: CI on this PR will install with the new `npm ci`. Once green and merged, re-tag v0.1.0.