### PR TITLE
fix(release): pre-populate desktop/node_modules so electron-builder skips its prod install

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - 'v*.*.*'
+  workflow_dispatch:
 
 permissions:
   contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,32 +37,16 @@ jobs:
         run: npm -w @claude-twin/mcp-server run build
 
       # electron-builder's "installing production dependencies" step runs
-      # `npm install --production` inside `desktop/`, which prunes
-      # devDependencies — taking app-builder-bin (and its platform-specific
-      # binaries) with it, then immediately ENOENT'ing on the binary it
-      # just deleted. Pre-populating desktop/node_modules ourselves makes
-      # electron-builder see a populated appDir and skip its own install.
-      #
-      # Two complications:
-      # 1. `@claude-twin/mcp-server` is a workspace sibling, not on npm —
-      #    we copy it into desktop/node_modules first so the install can
-      #    resolve everything else from the registry without --workspaces.
-      # 2. `--workspaces=false` keeps npm from reaching up to the root
-      #    workspace and re-running root-level installs.
+      # `npm install --production` inside `desktop/` and prunes the
+      # workspace-hoisted devDeps from root — taking app-builder-bin
+      # with them and ENOENT'ing on the binary it just deleted.
+      # Pre-populating desktop/node_modules sidesteps that. The
+      # `@claude-twin/mcp-server` dep uses the `file:../mcp-server` spec
+      # in desktop/package.json so this install resolves locally without
+      # the registry.
       - name: Pre-populate desktop/node_modules
         shell: bash
         run: |
-          # Hand-stage the workspace sibling. Includes the dist/ tree built
-          # by the previous step so dynamic imports of
-          # @claude-twin/mcp-server/dist/... resolve at runtime.
-          mkdir -p desktop/node_modules/@claude-twin
-          rm -rf desktop/node_modules/@claude-twin/mcp-server
-          cp -R mcp-server desktop/node_modules/@claude-twin/mcp-server
-          # Drop the staged copy's own node_modules + lockfile so npm doesn't
-          # try to re-resolve them.
-          rm -rf desktop/node_modules/@claude-twin/mcp-server/node_modules
-          rm -f  desktop/node_modules/@claude-twin/mcp-server/package-lock.json
-
           cd desktop
           npm install --no-package-lock --no-fund --no-audit --workspaces=false
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,14 +32,23 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      # Defensive: force-rebuild app-builder-bin so its prebuilt binaries
-      # land on disk even if npm ci skipped them. Cheap (no compile —
-      # the binaries ship inside the npm tarball).
-      - name: Ensure app-builder-bin binaries
-        run: npm rebuild app-builder-bin
-
       - name: Build mcp-server
         run: npm -w @claude-twin/mcp-server run build
+
+      # electron-builder's "installing production dependencies" step runs
+      # `npm install --production` inside `desktop/`, which would prune
+      # devDependencies — taking app-builder-bin (and its platform-specific
+      # binaries) with it, then immediately ENOENT'ing on the binary it
+      # just deleted. Pre-populating desktop/node_modules with the full
+      # dep tree (deps + devDeps) makes electron-builder skip its own
+      # install entirely.
+      - name: Pre-populate desktop/node_modules
+        shell: bash
+        run: |
+          cd desktop
+          # Don't write a per-package lockfile (the workspace lockfile is
+          # the source of truth); don't reach back to the root workspace.
+          npm install --no-package-lock --no-fund --no-audit --workspaces=false
 
       - name: Build + package desktop
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,18 +37,33 @@ jobs:
         run: npm -w @claude-twin/mcp-server run build
 
       # electron-builder's "installing production dependencies" step runs
-      # `npm install --production` inside `desktop/`, which would prune
+      # `npm install --production` inside `desktop/`, which prunes
       # devDependencies — taking app-builder-bin (and its platform-specific
       # binaries) with it, then immediately ENOENT'ing on the binary it
-      # just deleted. Pre-populating desktop/node_modules with the full
-      # dep tree (deps + devDeps) makes electron-builder skip its own
-      # install entirely.
+      # just deleted. Pre-populating desktop/node_modules ourselves makes
+      # electron-builder see a populated appDir and skip its own install.
+      #
+      # Two complications:
+      # 1. `@claude-twin/mcp-server` is a workspace sibling, not on npm —
+      #    we copy it into desktop/node_modules first so the install can
+      #    resolve everything else from the registry without --workspaces.
+      # 2. `--workspaces=false` keeps npm from reaching up to the root
+      #    workspace and re-running root-level installs.
       - name: Pre-populate desktop/node_modules
         shell: bash
         run: |
+          # Hand-stage the workspace sibling. Includes the dist/ tree built
+          # by the previous step so dynamic imports of
+          # @claude-twin/mcp-server/dist/... resolve at runtime.
+          mkdir -p desktop/node_modules/@claude-twin
+          rm -rf desktop/node_modules/@claude-twin/mcp-server
+          cp -R mcp-server desktop/node_modules/@claude-twin/mcp-server
+          # Drop the staged copy's own node_modules + lockfile so npm doesn't
+          # try to re-resolve them.
+          rm -rf desktop/node_modules/@claude-twin/mcp-server/node_modules
+          rm -f  desktop/node_modules/@claude-twin/mcp-server/package-lock.json
+
           cd desktop
-          # Don't write a per-package lockfile (the workspace lockfile is
-          # the source of truth); don't reach back to the root workspace.
           npm install --no-package-lock --no-fund --no-audit --workspaces=false
 
       - name: Build + package desktop

--- a/desktop/electron-builder.yml
+++ b/desktop/electron-builder.yml
@@ -17,8 +17,13 @@ mac:
       arch:
         - arm64
         - x64
-  hardenedRuntime: true
+  # Until MAC_CSC_LINK + APPLE_ID secrets are configured, builds are
+  # ad-hoc signed only. hardenedRuntime requires real signing for the
+  # app to launch. Override per-build via `--config.mac.hardenedRuntime=true
+  # --config.mac.identity=auto` once Developer ID is set.
+  hardenedRuntime: false
   gatekeeperAssess: false
+  identity: null
 win:
   target:
     - target: nsis

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -20,7 +20,7 @@
     "package:linux": "electron-vite build && electron-builder --linux --publish never"
   },
   "dependencies": {
-    "@claude-twin/mcp-server": "0.1.0",
+    "@claude-twin/mcp-server": "file:../mcp-server",
     "better-sqlite3": "^11.3.0",
     "electron-updater": "^6.3.9",
     "react": "^18.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "@claude-twin/mcp-server": "0.1.0",
+        "@claude-twin/mcp-server": "file:../mcp-server",
         "better-sqlite3": "^11.3.0",
         "electron-updater": "^6.3.9",
         "react": "^18.3.1",


### PR DESCRIPTION
Fourth attempt at unblocking the v0.1.0 release. Diagnostic on the previous debug branch (#101) showed the binary IS on disk and IS runnable, but electron-builder's internal 'installing production dependencies' step prunes devDependencies (including `app-builder-bin`) right before it tries to spawn `app-builder`. Pre-populating `desktop/node_modules` short-circuits that.

Will dispatch via workflow_dispatch + verify on this branch before merging + retagging v0.1.0.