### PR TITLE
fix: v0.1.1 — shim install, plugin marketplace, popup token field

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://schemas.claude.com/claude-code/marketplace.json",
+  "name": "claude-twin",
+  "owner": {
+    "name": "Fady Mondy",
+    "email": "info@3x1.io",
+    "url": "https://github.com/fadymondy"
+  },
+  "plugins": [
+    {
+      "name": "claude-twin",
+      "source": "./plugin",
+      "description": "Drive 17 web apps (Gmail, Slack, WhatsApp, Discord, Telegram, X, GitHub, Linear, Jira, GCal, Cal.com, Google Meet, Zoom, GCP, Claude.ai, OpenAI, Perplexity) from inside a Claude Code conversation.",
+      "version": "0.1.1",
+      "category": "automation",
+      "keywords": ["mcp", "chrome-extension", "browser-automation", "digital-twin", "monitor"]
+    }
+  ]
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.1.0] — 2026-04-29
+## [0.1.1] — 2026-04-29
+
+Patch release fixing three v0.1.0 install-day defects.
+
+### Fixed
+
+- **Desktop**: `claude-twin-mcp` shim was packaged inside `app.asar` instead of `Resources/shim/`, so the symlink the first-launch installer dropped into `~/.local/bin` pointed at a path that didn't exist. The symlink existed but `which claude-twin-mcp` failed and Claude Code's MCP discovery couldn't reach the server. Moved `shim/` to `extraResources` in `desktop/electron-builder.yml` so it lands at `Contents/Resources/shim/` outside the asar archive.
+- **Plugin**: `claude plugin install fadymondy/claude-twin` failed because the manifest lived at `plugin/.claude-plugin/plugin.json` but the marketplace resolver expects `.claude-plugin/marketplace.json` at the repo root. Added a root marketplace.json that references the existing `plugin/` directory — no need to relocate the plugin sources.
+- **Extension**: the popup's Status tab had no token field, so when the desktop bridge required a token (always — `ensureToken()` generates one on first launch) the WebSocket auth failed silently with close code 4401 and the offscreen reconnected indefinitely with the same wrong (or absent) token. Added a token input + Save button to the popup; the offscreen now force-reconnects on token change instead of waiting up to 30 s on the existing backoff.
 
 First public release. Five surfaces — Chrome extension, MCP server, Electron desktop app, Claude Code plugin, VSCode extension — installable via `.dmg` / `.exe` / `.AppImage` + `claude plugin install`.
 

--- a/desktop/electron-builder.yml
+++ b/desktop/electron-builder.yml
@@ -5,10 +5,15 @@ directories:
   buildResources: resources
 files:
   - out/**/*
-  - shim/**/*
   - resources/**/*
   - package.json
   - '!**/*.{md,test.ts,spec.ts}'
+# shim/ must live OUTSIDE app.asar — cli-install.ts symlinks
+# `Resources/shim/claude-twin-mcp.cjs` onto the user's PATH, and a path
+# inside an asar archive isn't directly executable by node.
+extraResources:
+  - from: shim
+    to: shim
 asar: true
 mac:
   category: public.app-category.developer-tools

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@claude-twin/desktop",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "description": "Electron desktop app — bundles the MCP server and WS bridge, renders live twin events",
   "license": "MIT",

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "claude-twin",
   "short_name": "claude-twin",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Real-time browser monitoring for your digital twin — drives 17 web apps from Claude Code via a local MCP server.",
   "minimum_chrome_version": "120",
   "action": {

--- a/extension/offscreen/offscreen.js
+++ b/extension/offscreen/offscreen.js
@@ -261,6 +261,16 @@ chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
       token = payload.token;
       if (isConnected) {
         send({ type: 'auth', token, extension_id: extensionId });
+      } else {
+        // Bridge likely closed the prior socket on bad-auth (4401).
+        // Drop any pending backoff and reconnect now so the new token
+        // takes effect without waiting up to 30s.
+        if (reconnectTimer) {
+          clearTimeout(reconnectTimer);
+          reconnectTimer = null;
+        }
+        reconnectAttempt = 0;
+        connect();
       }
     }
     sendResponse({ ok: true });

--- a/extension/popup/popup.css
+++ b/extension/popup/popup.css
@@ -244,3 +244,43 @@ footer a {
 footer a:hover {
   text-decoration: underline;
 }
+
+.token-row {
+  margin-top: 12px;
+  padding-top: 10px;
+  border-top: 1px solid var(--border);
+}
+
+.token-row .label {
+  display: block;
+  font-size: 11px;
+  font-weight: 600;
+  margin-bottom: 4px;
+}
+
+.token-input-row {
+  display: flex;
+  gap: 6px;
+  align-items: stretch;
+}
+
+.token-input-row input {
+  flex: 1;
+  padding: 6px 8px;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  font-family: ui-monospace, SFMono-Regular, monospace;
+  font-size: 11px;
+  background: var(--bg);
+  color: var(--fg);
+}
+
+.token-input-row button {
+  padding: 6px 10px;
+  font-size: 11px;
+}
+
+.hint {
+  margin-top: 6px;
+  font-size: 10px;
+}

--- a/extension/popup/popup.html
+++ b/extension/popup/popup.html
@@ -62,6 +62,23 @@
           <span>Privacy mode</span>
         </label>
       </div>
+      <div class="token-row">
+        <label class="label" for="token-input">Bridge token</label>
+        <div class="token-input-row">
+          <input
+            type="password"
+            id="token-input"
+            placeholder="Paste from desktop Settings"
+            autocomplete="off"
+            spellcheck="false"
+          />
+          <button id="token-reveal" class="secondary" type="button" title="Show / hide">👁</button>
+          <button id="token-save" type="button">Save</button>
+        </div>
+        <p id="token-hint" class="muted hint">
+          Open the desktop app → Settings → copy the WS token, paste here.
+        </p>
+      </div>
     </section>
 
     <section data-pane="monitors" class="pane hidden">

--- a/extension/popup/popup.js
+++ b/extension/popup/popup.js
@@ -29,6 +29,10 @@ const els = {
   updateVersion: document.getElementById('update-version'),
   updateLink: document.getElementById('update-link'),
   updateRecheck: document.getElementById('update-recheck'),
+  tokenInput: document.getElementById('token-input'),
+  tokenReveal: document.getElementById('token-reveal'),
+  tokenSave: document.getElementById('token-save'),
+  tokenHint: document.getElementById('token-hint'),
 };
 
 const PLATFORM_ORIGINS = [
@@ -222,6 +226,28 @@ els.privacy.addEventListener('change', async (e) => {
   void renderStatus();
 });
 
+async function renderToken() {
+  const { token } = await chrome.storage.local.get('token');
+  els.tokenInput.value = token || '';
+}
+
+els.tokenReveal?.addEventListener('click', () => {
+  els.tokenInput.type = els.tokenInput.type === 'password' ? 'text' : 'password';
+});
+
+els.tokenSave?.addEventListener('click', async () => {
+  const value = els.tokenInput.value.trim();
+  const response = await send('setToken', { value });
+  if (response?.ok) {
+    els.tokenHint.textContent = value
+      ? 'Saved. Reconnecting…'
+      : 'Cleared. Bridge auth disabled (only works if desktop has no token).';
+    setTimeout(() => void renderStatus(), 800);
+  } else {
+    els.tokenHint.textContent = `Save failed: ${response?.error || 'unknown error'}`;
+  }
+});
+
 function formatAgo(ms) {
   const sec = Math.floor(ms / 1000);
   if (sec < 60) return `${sec}s ago`;
@@ -257,6 +283,7 @@ els.updateRecheck?.addEventListener('click', async () => {
 document.addEventListener('DOMContentLoaded', async () => {
   activateTab('status');
   await renderStatus();
+  await renderToken();
   await renderMeetingPrompt();
   await renderUpdateBanner();
 });

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@claude-twin/mcp-server",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "description": "Local MCP server hosting the WebSocket bridge to the claude-twin Chrome extension",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-twin",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "description": "Standalone Chrome extension + MCP server + Claude Code plugin for browser-based digital twin monitoring",
   "license": "MIT",

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://schemas.claude.com/claude-code/plugin.json",
   "name": "claude-twin",
   "description": "Drive 17 web apps (Gmail, Slack, WhatsApp, Discord, Telegram, X, GitHub, Linear, Jira, GCal, Cal.com, Google Meet, Zoom, GCP, Claude.ai, OpenAI, Perplexity) from inside a Claude Code conversation. Uses a local Chrome extension + the claude-twin desktop app — nothing leaves your machine.",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "author": {
     "name": "Fady Mondy",
     "email": "info@3x1.io",

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@claude-twin/plugin",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "description": "Claude Code plugin manifest for claude-twin — auto-registers the MCP server and ships slash commands",
   "license": "MIT",

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "@claude-twin/vscode-extension",
   "displayName": "claude-twin",
   "description": "Drive the claude-twin desktop app — read / send / click / watch on 17 web apps — from inside VSCode.",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "license": "MIT",
   "publisher": "fadymondy",


### PR DESCRIPTION
## Summary
Three v0.1.0 install-day defects, all user-visible on first launch.

1. **Desktop shim inside `app.asar`** — the first-launch installer symlinked `~/.local/bin/claude-twin-mcp → /Applications/claude-twin.app/Contents/Resources/shim/claude-twin-mcp.cjs`, but `shim/` was packed inside `app.asar` (because it was listed under `files:` in `electron-builder.yml`). The symlink existed but its target didn't, so `which claude-twin-mcp` failed and Claude Code MCP discovery couldn't reach the server. Fix: move `shim/` to `extraResources` so it lands at `Resources/shim/` outside the asar.

2. **Plugin install fails** — `claude plugin install fadymondy/claude-twin` looks for `.claude-plugin/marketplace.json` at the repo root, but the plugin manifest lived at `plugin/.claude-plugin/plugin.json`. Added a root `marketplace.json` that references the existing `plugin/` directory — no relocation needed.

3. **Popup has no token field** — the bridge always requires a token (`ensureToken()` generates one on first launch), but the popup has Status / Monitors / Scripts / Permissions tabs and no token input. Auth silently failed with WS close 4401 and the offscreen reconnected indefinitely with the wrong token. Added a token field + Save button to the Status tab; the offscreen now force-reconnects on token change instead of waiting up to 30s on the existing backoff.

Bumps versions to 0.1.1 across all 7 manifests.

## Test plan
- [x] `npm run lint && npm run format:check && npm run typecheck`
- [x] `npm -w @claude-twin/mcp-server run test` (18/18 pass)
- [ ] Verify the v0.1.1 release pipeline produces DMGs/exe/AppImage with `Resources/shim/claude-twin-mcp.cjs` outside the asar
- [ ] Manual: install v0.1.1 DMG → tray "Show details" → copy token → Chrome popup → paste → Save → verify auth flips to authenticated
- [ ] Manual: `claude plugin install fadymondy/claude-twin` succeeds against the v0.1.1 tag